### PR TITLE
feat: extended auth flows + RBAC system

### DIFF
--- a/migrations/0002_add_token_tables.sql
+++ b/migrations/0002_add_token_tables.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash VARCHAR(255) NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    used_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS email_verification_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash VARCHAR(255) NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    used_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_id ON password_reset_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_email_verification_tokens_user_id ON email_verification_tokens(user_id);

--- a/migrations/0002_add_token_tables.sql
+++ b/migrations/0002_add_token_tables.sql
@@ -18,3 +18,5 @@ CREATE TABLE IF NOT EXISTS email_verification_tokens (
 
 CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_id ON password_reset_tokens(user_id);
 CREATE INDEX IF NOT EXISTS idx_email_verification_tokens_user_id ON email_verification_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_token_hash ON password_reset_tokens(token_hash);
+CREATE INDEX IF NOT EXISTS idx_email_verification_tokens_token_hash ON email_verification_tokens(token_hash);

--- a/migrations/0003_add_rbac_tables.sql
+++ b/migrations/0003_add_rbac_tables.sql
@@ -1,0 +1,40 @@
+CREATE TABLE IF NOT EXISTS permissions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(100) NOT NULL UNIQUE,
+    description VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+    role_id UUID NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+    permission_id UUID NOT NULL REFERENCES permissions(id) ON DELETE CASCADE,
+    PRIMARY KEY (role_id, permission_id)
+);
+
+CREATE TABLE IF NOT EXISTS user_roles (
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role_id UUID NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+    PRIMARY KEY (user_id, role_id)
+);
+
+INSERT INTO permissions (name, description) VALUES
+    ('users.read', 'View users'),
+    ('users.write', 'Create and update users'),
+    ('users.delete', 'Delete users'),
+    ('roles.manage', 'Manage roles and permissions')
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id FROM roles r CROSS JOIN permissions p
+WHERE r.name = 'super_admin' AND p.name IN ('users.read', 'users.write', 'users.delete', 'roles.manage')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id FROM roles r CROSS JOIN permissions p
+WHERE r.name = 'admin' AND p.name IN ('users.read', 'users.write')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id FROM roles r CROSS JOIN permissions p
+WHERE r.name = 'user' AND p.name = 'users.read'
+ON CONFLICT DO NOTHING;

--- a/migrations/0003_add_rbac_tables.sql
+++ b/migrations/0003_add_rbac_tables.sql
@@ -18,23 +18,34 @@ CREATE TABLE IF NOT EXISTS user_roles (
 );
 
 INSERT INTO permissions (name, description) VALUES
-    ('users.read', 'View users'),
-    ('users.write', 'Create and update users'),
-    ('users.delete', 'Delete users'),
-    ('roles.manage', 'Manage roles and permissions')
+    ('users:read', 'View users'),
+    ('users:write', 'Create and update users'),
+    ('users:delete', 'Delete users'),
+    ('roles:read', 'View roles'),
+    ('roles:write', 'Create and update roles and assignments'),
+    ('roles:delete', 'Delete roles'),
+    ('permissions:read', 'View permissions'),
+    ('permissions:write', 'Create, update, and delete permissions')
 ON CONFLICT (name) DO NOTHING;
 
 INSERT INTO role_permissions (role_id, permission_id)
 SELECT r.id, p.id FROM roles r CROSS JOIN permissions p
-WHERE r.name = 'super_admin' AND p.name IN ('users.read', 'users.write', 'users.delete', 'roles.manage')
+WHERE r.name = 'super_admin' AND p.name IN (
+    'users:read', 'users:write', 'users:delete',
+    'roles:read', 'roles:write', 'roles:delete',
+    'permissions:read', 'permissions:write'
+)
 ON CONFLICT DO NOTHING;
 
 INSERT INTO role_permissions (role_id, permission_id)
 SELECT r.id, p.id FROM roles r CROSS JOIN permissions p
-WHERE r.name = 'admin' AND p.name IN ('users.read', 'users.write')
+WHERE r.name = 'admin' AND p.name IN (
+    'users:read', 'users:write',
+    'roles:read', 'permissions:read'
+)
 ON CONFLICT DO NOTHING;
 
 INSERT INTO role_permissions (role_id, permission_id)
 SELECT r.id, p.id FROM roles r CROSS JOIN permissions p
-WHERE r.name = 'user' AND p.name = 'users.read'
+WHERE r.name = 'user' AND false
 ON CONFLICT DO NOTHING;

--- a/src/handlers/admin.rs
+++ b/src/handlers/admin.rs
@@ -1,200 +1,487 @@
 use axum::{
     extract::{Path, State},
-    routing::{get, patch, post},
+    routing::{delete, get},
     Json, Router,
 };
-use chrono::{DateTime, Utc};
 use uuid::Uuid;
+use validator::Validate;
 
 use crate::{
     errors::AppError,
     middleware::auth::CurrentUser,
-    models::{
-        permission::Permission,
-        role::Role,
-        user::User,
-        user_role::UserRole as UserRoleModel,
-    },
+    models::{permission::Permission, role::Role, user::User, user_role::UserRole},
     schema::{
-        MessageData, MessageResponse, PermissionResponse, RolePermissionRequest,
-        UserResponse, UserRoleRequest, UserUpdateRequest,
+        ApiResponse, AssignPermissionRequest, AssignRoleRequest, CreatePermissionRequest,
+        CreateRoleRequest, CreateUserRequest, MessageData, PermissionResponseData,
+        RoleResponseData, UpdatePermissionRequest, UpdateRoleRequest, UpdateUserRequest,
+        UserResponseData,
     },
+    services::auth::AuthService,
     AppState,
 };
 
 pub fn router() -> Router<AppState> {
     Router::new()
-        .route("/roles", get(list_roles))
-        .route("/permissions", get(list_permissions))
-        .route("/roles/{role_id}/permissions", get(get_role_permissions))
-        .route("/roles/permissions", post(assign_permission).delete(remove_permission))
-        .route("/users", get(list_users))
-        .route("/users/{user_id}", get(get_user).delete(delete_user))
-        .route("/users/{user_id}/patch", patch(update_user))
-        .route("/users/{user_id}/permissions", get(get_user_permissions))
-        .route("/users/roles", post(assign_role).delete(remove_role))
-}
-
-async fn require_perm(state: &AppState, user_id: Uuid, perm: &str) -> Result<(), AppError> {
-    let has = Permission::user_has_permission(&state.pool, user_id, perm)
-        .await
-        .map_err(|_| AppError::Internal("Permission check failed.".to_string()))?;
-    if !has {
-        return Err(AppError::Forbidden(format!("Permission '{}' is required.", perm)));
-    }
-    Ok(())
+        .route("/api/v1/roles", get(list_roles).post(create_role))
+        .route("/api/v1/roles/{role_id}", get(get_role).patch(update_role).delete(delete_role))
+        .route(
+            "/api/v1/roles/{role_id}/permissions",
+            get(list_role_permissions).post(assign_permission),
+        )
+        .route(
+            "/api/v1/roles/{role_id}/permissions/{permission_id}",
+            delete(remove_permission),
+        )
+        .route("/api/v1/permissions", get(list_permissions).post(create_permission))
+        .route(
+            "/api/v1/permissions/{permission_id}",
+            get(get_permission).patch(update_permission).delete(delete_permission),
+        )
+        .route("/api/v1/users", get(list_users).post(create_user))
+        .route(
+            "/api/v1/users/{user_id}",
+            get(get_user).patch(update_user).delete(delete_user),
+        )
+        .route("/api/v1/users/{user_id}/roles", get(list_user_roles).post(assign_role))
+        .route("/api/v1/users/{user_id}/roles/{role_id}", delete(remove_role))
+        .route("/api/v1/users/{user_id}/permissions", get(get_user_permissions))
 }
 
 async fn list_roles(
     State(state): State<AppState>,
-    user: CurrentUser,
-) -> Result<Json<Vec<RoleResponse>>, AppError> {
-    require_perm(&state, user.0.id, "roles.manage").await?;
+    current_user: CurrentUser,
+) -> Result<Json<ApiResponse<Vec<RoleResponseData>>>, AppError> {
+    current_user.require("roles:read")?;
     let roles = Role::all(&state.pool).await?;
-    Ok(Json(roles.into_iter().map(|r| RoleResponse {
-        id: r.id,
-        name: r.name,
-        created_at: r.created_at,
-    }).collect()))
+    let mut response = Vec::with_capacity(roles.len());
+
+    for role in roles {
+        let permissions = Permission::find_by_role_id(&state.pool, role.id).await?;
+        response.push(RoleResponseData::from_role(role, permissions));
+    }
+
+    Ok(Json(ApiResponse { data: response }))
 }
 
-async fn list_permissions(
+async fn create_role(
     State(state): State<AppState>,
-    user: CurrentUser,
-) -> Result<Json<Vec<PermissionResponse>>, AppError> {
-    require_perm(&state, user.0.id, "roles.manage").await?;
-    let perms = Permission::all(&state.pool).await?;
-    Ok(Json(perms.into_iter().map(|p| PermissionResponse {
-        id: p.id, name: p.name, description: p.description, created_at: p.created_at,
-    }).collect()))
+    current_user: CurrentUser,
+    Json(payload): Json<CreateRoleRequest>,
+) -> Result<(axum::http::StatusCode, Json<ApiResponse<RoleResponseData>>), AppError> {
+    current_user.require("roles:write")?;
+    payload.validate()?;
+    let normalized_name = payload.name.trim().to_lowercase();
+
+    if Role::find_by_name(&state.pool, &normalized_name).await?.is_some() {
+        return Err(AppError::Conflict("A role with this name already exists.".to_string()));
+    }
+
+    let role = Role::create(&state.pool, &normalized_name).await?;
+    Ok((
+        axum::http::StatusCode::CREATED,
+        Json(ApiResponse {
+            data: RoleResponseData::from_role(role, Vec::new()),
+        }),
+    ))
 }
 
-async fn get_role_permissions(
+async fn get_role(
     State(state): State<AppState>,
-    user: CurrentUser,
+    current_user: CurrentUser,
     Path(role_id): Path<Uuid>,
-) -> Result<Json<Vec<PermissionResponse>>, AppError> {
-    require_perm(&state, user.0.id, "roles.manage").await?;
-    let perms = Permission::find_by_role_id(&state.pool, role_id).await?;
-    Ok(Json(perms.into_iter().map(|p| PermissionResponse {
-        id: p.id, name: p.name, description: p.description, created_at: p.created_at,
-    }).collect()))
+) -> Result<Json<ApiResponse<RoleResponseData>>, AppError> {
+    current_user.require("roles:read")?;
+    let role = Role::find_by_id(&state.pool, role_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Role not found.".to_string()))?;
+    let permissions = Permission::find_by_role_id(&state.pool, role_id).await?;
+
+    Ok(Json(ApiResponse {
+        data: RoleResponseData::from_role(role, permissions),
+    }))
+}
+
+async fn update_role(
+    State(state): State<AppState>,
+    current_user: CurrentUser,
+    Path(role_id): Path<Uuid>,
+    Json(payload): Json<UpdateRoleRequest>,
+) -> Result<Json<ApiResponse<RoleResponseData>>, AppError> {
+    current_user.require("roles:write")?;
+    payload.validate()?;
+    let normalized_name = payload.name.trim().to_lowercase();
+    let existing = Role::find_by_name(&state.pool, &normalized_name).await?;
+    if let Some(existing_role) = existing {
+        if existing_role.id != role_id {
+            return Err(AppError::Conflict("A role with this name already exists.".to_string()));
+        }
+    }
+
+    let _ = Role::find_by_id(&state.pool, role_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Role not found.".to_string()))?;
+    let role = Role::update(&state.pool, role_id, &normalized_name).await?;
+    let permissions = Permission::find_by_role_id(&state.pool, role_id).await?;
+
+    Ok(Json(ApiResponse {
+        data: RoleResponseData::from_role(role, permissions),
+    }))
+}
+
+async fn delete_role(
+    State(state): State<AppState>,
+    current_user: CurrentUser,
+    Path(role_id): Path<Uuid>,
+) -> Result<Json<ApiResponse<MessageData>>, AppError> {
+    current_user.require("roles:delete")?;
+    let _ = Role::find_by_id(&state.pool, role_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Role not found.".to_string()))?;
+    Role::delete(&state.pool, role_id).await?;
+
+    Ok(Json(ApiResponse {
+        data: MessageData {
+            message: "Role deleted successfully.".to_string(),
+        },
+    }))
+}
+
+async fn list_role_permissions(
+    State(state): State<AppState>,
+    current_user: CurrentUser,
+    Path(role_id): Path<Uuid>,
+) -> Result<Json<ApiResponse<Vec<PermissionResponseData>>>, AppError> {
+    current_user.require("roles:read")?;
+    let _ = Role::find_by_id(&state.pool, role_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Role not found.".to_string()))?;
+    let permissions = Permission::find_by_role_id(&state.pool, role_id).await?;
+
+    Ok(Json(ApiResponse {
+        data: permissions
+            .iter()
+            .map(PermissionResponseData::from)
+            .collect(),
+    }))
 }
 
 async fn assign_permission(
     State(state): State<AppState>,
-    user: CurrentUser,
-    Json(payload): Json<RolePermissionRequest>,
-) -> Result<Json<MessageResponse>, AppError> {
-    require_perm(&state, user.0.id, "roles.manage").await?;
-    Permission::assign_to_role(&state.pool, payload.role_id, payload.permission_id).await?;
-    Ok(Json(MessageResponse { data: MessageData { message: "Permission assigned to role.".to_string() } }))
+    current_user: CurrentUser,
+    Path(role_id): Path<Uuid>,
+    Json(payload): Json<AssignPermissionRequest>,
+) -> Result<Json<ApiResponse<RoleResponseData>>, AppError> {
+    current_user.require("roles:write")?;
+    let role = Role::find_by_id(&state.pool, role_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Role not found.".to_string()))?;
+    let _ = Permission::find_by_id(&state.pool, payload.permission_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Permission not found.".to_string()))?;
+    Permission::assign_to_role(&state.pool, role_id, payload.permission_id).await?;
+    let permissions = Permission::find_by_role_id(&state.pool, role_id).await?;
+
+    Ok(Json(ApiResponse {
+        data: RoleResponseData::from_role(role, permissions),
+    }))
 }
 
 async fn remove_permission(
     State(state): State<AppState>,
-    user: CurrentUser,
-    Json(payload): Json<RolePermissionRequest>,
-) -> Result<Json<MessageResponse>, AppError> {
-    require_perm(&state, user.0.id, "roles.manage").await?;
-    Permission::remove_from_role(&state.pool, payload.role_id, payload.permission_id).await?;
-    Ok(Json(MessageResponse { data: MessageData { message: "Permission removed from role.".to_string() } }))
+    current_user: CurrentUser,
+    Path((role_id, permission_id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<ApiResponse<RoleResponseData>>, AppError> {
+    current_user.require("roles:write")?;
+    let role = Role::find_by_id(&state.pool, role_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Role not found.".to_string()))?;
+    let _ = Permission::find_by_id(&state.pool, permission_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Permission not found.".to_string()))?;
+    Permission::remove_from_role(&state.pool, role_id, permission_id).await?;
+    let permissions = Permission::find_by_role_id(&state.pool, role_id).await?;
+
+    Ok(Json(ApiResponse {
+        data: RoleResponseData::from_role(role, permissions),
+    }))
+}
+
+async fn list_permissions(
+    State(state): State<AppState>,
+    current_user: CurrentUser,
+) -> Result<Json<ApiResponse<Vec<PermissionResponseData>>>, AppError> {
+    current_user.require("permissions:read")?;
+    let permissions = Permission::all(&state.pool).await?;
+
+    Ok(Json(ApiResponse {
+        data: permissions
+            .iter()
+            .map(PermissionResponseData::from)
+            .collect(),
+    }))
+}
+
+async fn create_permission(
+    State(state): State<AppState>,
+    current_user: CurrentUser,
+    Json(payload): Json<CreatePermissionRequest>,
+) -> Result<(axum::http::StatusCode, Json<ApiResponse<PermissionResponseData>>), AppError> {
+    current_user.require("permissions:write")?;
+    payload.validate()?;
+    let normalized_name = payload.name.trim().to_lowercase();
+
+    if Permission::find_by_name(&state.pool, &normalized_name)
+        .await?
+        .is_some()
+    {
+        return Err(AppError::Conflict(
+            "A permission with this name already exists.".to_string(),
+        ));
+    }
+
+    let permission = Permission::create(
+        &state.pool,
+        &normalized_name,
+        payload.description.trim(),
+    )
+    .await?;
+
+    Ok((
+        axum::http::StatusCode::CREATED,
+        Json(ApiResponse {
+            data: PermissionResponseData::from(permission),
+        }),
+    ))
+}
+
+async fn get_permission(
+    State(state): State<AppState>,
+    current_user: CurrentUser,
+    Path(permission_id): Path<Uuid>,
+) -> Result<Json<ApiResponse<PermissionResponseData>>, AppError> {
+    current_user.require("permissions:read")?;
+    let permission = Permission::find_by_id(&state.pool, permission_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Permission not found.".to_string()))?;
+
+    Ok(Json(ApiResponse {
+        data: PermissionResponseData::from(permission),
+    }))
+}
+
+async fn update_permission(
+    State(state): State<AppState>,
+    current_user: CurrentUser,
+    Path(permission_id): Path<Uuid>,
+    Json(payload): Json<UpdatePermissionRequest>,
+) -> Result<Json<ApiResponse<PermissionResponseData>>, AppError> {
+    current_user.require("permissions:write")?;
+    payload.validate()?;
+    let normalized_name = payload.name.trim().to_lowercase();
+    let existing = Permission::find_by_name(&state.pool, &normalized_name).await?;
+    if let Some(existing_permission) = existing {
+        if existing_permission.id != permission_id {
+            return Err(AppError::Conflict(
+                "A permission with this name already exists.".to_string(),
+            ));
+        }
+    }
+
+    let _ = Permission::find_by_id(&state.pool, permission_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Permission not found.".to_string()))?;
+    let permission = Permission::update(
+        &state.pool,
+        permission_id,
+        &normalized_name,
+        payload.description.trim(),
+    )
+    .await?;
+
+    Ok(Json(ApiResponse {
+        data: PermissionResponseData::from(permission),
+    }))
+}
+
+async fn delete_permission(
+    State(state): State<AppState>,
+    current_user: CurrentUser,
+    Path(permission_id): Path<Uuid>,
+) -> Result<Json<ApiResponse<MessageData>>, AppError> {
+    current_user.require("permissions:write")?;
+    let _ = Permission::find_by_id(&state.pool, permission_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Permission not found.".to_string()))?;
+    Permission::delete(&state.pool, permission_id).await?;
+
+    Ok(Json(ApiResponse {
+        data: MessageData {
+            message: "Permission deleted successfully.".to_string(),
+        },
+    }))
 }
 
 async fn list_users(
     State(state): State<AppState>,
-    user: CurrentUser,
-) -> Result<Json<Vec<UserResponse>>, AppError> {
-    require_perm(&state, user.0.id, "users.read").await?;
-    let users = sqlx::query_as::<_, User>(
-        "SELECT id, email, password_hash, first_name, last_name, is_active, is_verified, created_at, updated_at FROM users ORDER BY created_at DESC"
-    ).fetch_all(&state.pool).await?;
-    Ok(Json(users.iter().map(|u| crate::schema::UserResponseData::from(u).into()).collect()))
+    current_user: CurrentUser,
+) -> Result<Json<ApiResponse<Vec<UserResponseData>>>, AppError> {
+    current_user.require("users:read")?;
+    let users = User::list(&state.pool).await?;
+    let service = AuthService::new(state);
+    let mut response = Vec::with_capacity(users.len());
+
+    for user in users {
+        response.push(service.build_user_response(user.id).await?);
+    }
+
+    Ok(Json(ApiResponse { data: response }))
+}
+
+async fn create_user(
+    State(state): State<AppState>,
+    current_user: CurrentUser,
+    Json(payload): Json<CreateUserRequest>,
+) -> Result<(axum::http::StatusCode, Json<ApiResponse<UserResponseData>>), AppError> {
+    current_user.require("users:write")?;
+    payload.validate()?;
+    let user = AuthService::new(state).create_user(payload).await?;
+
+    Ok((axum::http::StatusCode::CREATED, Json(ApiResponse { data: user })))
 }
 
 async fn get_user(
     State(state): State<AppState>,
-    user: CurrentUser,
+    current_user: CurrentUser,
     Path(user_id): Path<Uuid>,
-) -> Result<Json<UserResponse>, AppError> {
-    require_perm(&state, user.0.id, "users.read").await?;
-    let found = User::find_active_by_id(&state.pool, user_id).await?.ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
-    Ok(Json(UserResponse { data: crate::schema::UserResponseData::from(&found) }))
+) -> Result<Json<ApiResponse<UserResponseData>>, AppError> {
+    current_user.require("users:read")?;
+    let user = AuthService::new(state).build_user_response(user_id).await?;
+    Ok(Json(ApiResponse { data: user }))
 }
 
 async fn update_user(
     State(state): State<AppState>,
-    user: CurrentUser,
+    current_user: CurrentUser,
     Path(user_id): Path<Uuid>,
-    Json(payload): Json<UserUpdateRequest>,
-) -> Result<Json<UserResponse>, AppError> {
-    require_perm(&state, user.0.id, "users.write").await?;
-    let mut found = User::find_active_by_id(&state.pool, user_id).await?.ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
-    if let Some(ref first_name) = payload.first_name { found.first_name = first_name.clone(); }
-    if let Some(ref last_name) = payload.last_name { found.last_name = last_name.clone(); }
-    if let Some(is_active) = payload.is_active {
-        sqlx::query("UPDATE users SET is_active = $1, updated_at = NOW() WHERE id = $2")
-            .bind(is_active).bind(user_id).execute(&state.pool).await?;
-    }
-    sqlx::query("UPDATE users SET first_name = $1, last_name = $2, updated_at = NOW() WHERE id = $3")
-        .bind(&found.first_name).bind(&found.last_name).bind(user_id)
-        .execute(&state.pool).await?;
-    let updated = User::find_active_by_id(&state.pool, user_id).await?.ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
-    Ok(Json(UserResponse { data: crate::schema::UserResponseData::from(&updated) }))
+    Json(payload): Json<UpdateUserRequest>,
+) -> Result<Json<ApiResponse<UserResponseData>>, AppError> {
+    current_user.require("users:write")?;
+    payload.validate()?;
+    let existing = User::find_by_id(&state.pool, user_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
+    let updated = User::update(
+        &state.pool,
+        user_id,
+        payload
+            .first_name
+            .as_deref()
+            .unwrap_or(existing.first_name.as_str())
+            .trim(),
+        payload
+            .last_name
+            .as_deref()
+            .unwrap_or(existing.last_name.as_str())
+            .trim(),
+        payload.is_active.unwrap_or(existing.is_active),
+        payload.is_verified.unwrap_or(existing.is_verified),
+    )
+    .await?;
+
+    let user = AuthService::new(state).build_user_response(updated.id).await?;
+    Ok(Json(ApiResponse { data: user }))
 }
 
 async fn delete_user(
     State(state): State<AppState>,
-    user: CurrentUser,
+    current_user: CurrentUser,
     Path(user_id): Path<Uuid>,
-) -> Result<Json<MessageResponse>, AppError> {
-    require_perm(&state, user.0.id, "users.delete").await?;
-    let _ = User::find_active_by_id(&state.pool, user_id).await?.ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
-    sqlx::query("DELETE FROM users WHERE id = $1").bind(user_id).execute(&state.pool).await?;
-    Ok(Json(MessageResponse { data: MessageData { message: "User deleted.".to_string() } }))
+) -> Result<Json<ApiResponse<MessageData>>, AppError> {
+    current_user.require("users:delete")?;
+    let _ = User::find_by_id(&state.pool, user_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
+    User::delete(&state.pool, user_id).await?;
+
+    Ok(Json(ApiResponse {
+        data: MessageData {
+            message: "User deleted successfully.".to_string(),
+        },
+    }))
 }
 
-async fn get_user_permissions(
+async fn list_user_roles(
     State(state): State<AppState>,
-    user: CurrentUser,
-    Path(target_user_id): Path<Uuid>,
-) -> Result<Json<Vec<PermissionResponse>>, AppError> {
-    require_perm(&state, user.0.id, "users.read").await?;
-    let perms = Permission::find_by_user_id(&state.pool, target_user_id).await?;
-    Ok(Json(perms.into_iter().map(|p| PermissionResponse {
-        id: p.id, name: p.name, description: p.description, created_at: p.created_at,
-    }).collect()))
+    current_user: CurrentUser,
+    Path(user_id): Path<Uuid>,
+) -> Result<Json<ApiResponse<Vec<RoleResponseData>>>, AppError> {
+    current_user.require("users:read")?;
+    let _ = User::find_by_id(&state.pool, user_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
+    let roles = UserRole::list_by_user_id(&state.pool, user_id).await?;
+    let mut response = Vec::with_capacity(roles.len());
+
+    for role in roles {
+        let permissions = Permission::find_by_role_id(&state.pool, role.id).await?;
+        response.push(RoleResponseData::from_role(role, permissions));
+    }
+
+    Ok(Json(ApiResponse { data: response }))
 }
 
 async fn assign_role(
     State(state): State<AppState>,
-    user: CurrentUser,
-    Json(payload): Json<UserRoleRequest>,
-) -> Result<Json<MessageResponse>, AppError> {
-    require_perm(&state, user.0.id, "roles.manage").await?;
-    UserRoleModel::assign(&state.pool, payload.user_id, payload.role_id).await?;
-    Ok(Json(MessageResponse { data: MessageData { message: "Role assigned to user.".to_string() } }))
+    current_user: CurrentUser,
+    Path(user_id): Path<Uuid>,
+    Json(payload): Json<AssignRoleRequest>,
+) -> Result<Json<ApiResponse<UserResponseData>>, AppError> {
+    current_user.require("users:write")?;
+    let _ = User::find_by_id(&state.pool, user_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
+    let _ = Role::find_by_id(&state.pool, payload.role_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Role not found.".to_string()))?;
+    UserRole::assign(&state.pool, user_id, payload.role_id).await?;
+
+    let user = AuthService::new(state).build_user_response(user_id).await?;
+    Ok(Json(ApiResponse { data: user }))
 }
 
 async fn remove_role(
     State(state): State<AppState>,
-    user: CurrentUser,
-    Json(payload): Json<UserRoleRequest>,
-) -> Result<Json<MessageResponse>, AppError> {
-    require_perm(&state, user.0.id, "roles.manage").await?;
-    UserRoleModel::remove(&state.pool, payload.user_id, payload.role_id).await?;
-    Ok(Json(MessageResponse { data: MessageData { message: "Role removed from user.".to_string() } }))
+    current_user: CurrentUser,
+    Path((user_id, role_id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<ApiResponse<UserResponseData>>, AppError> {
+    current_user.require("users:write")?;
+    let _ = User::find_by_id(&state.pool, user_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
+    let _ = Role::find_by_id(&state.pool, role_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Role not found.".to_string()))?;
+    UserRole::remove(&state.pool, user_id, role_id).await?;
+
+    let user = AuthService::new(state).build_user_response(user_id).await?;
+    Ok(Json(ApiResponse { data: user }))
 }
 
-impl From<crate::schema::UserResponseData> for UserResponse {
-    fn from(data: crate::schema::UserResponseData) -> Self {
-        Self { data }
-    }
-}
+async fn get_user_permissions(
+    State(state): State<AppState>,
+    current_user: CurrentUser,
+    Path(user_id): Path<Uuid>,
+) -> Result<Json<ApiResponse<Vec<PermissionResponseData>>>, AppError> {
+    current_user.require("users:read")?;
+    let _ = User::find_by_id(&state.pool, user_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
+    let permissions = Permission::find_by_user_id(&state.pool, user_id).await?;
 
-#[derive(Debug, serde::Serialize)]
-pub struct RoleResponse {
-    pub id: Uuid,
-    pub name: String,
-    pub created_at: DateTime<Utc>,
+    Ok(Json(ApiResponse {
+        data: permissions
+            .iter()
+            .map(PermissionResponseData::from)
+            .collect(),
+    }))
 }

--- a/src/handlers/admin.rs
+++ b/src/handlers/admin.rs
@@ -1,0 +1,200 @@
+use axum::{
+    extract::{Path, State},
+    routing::{get, patch, post},
+    Json, Router,
+};
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::{
+    errors::AppError,
+    middleware::auth::CurrentUser,
+    models::{
+        permission::Permission,
+        role::Role,
+        user::User,
+        user_role::UserRole as UserRoleModel,
+    },
+    schema::{
+        MessageData, MessageResponse, PermissionResponse, RolePermissionRequest,
+        UserResponse, UserRoleRequest, UserUpdateRequest,
+    },
+    AppState,
+};
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/roles", get(list_roles))
+        .route("/permissions", get(list_permissions))
+        .route("/roles/{role_id}/permissions", get(get_role_permissions))
+        .route("/roles/permissions", post(assign_permission).delete(remove_permission))
+        .route("/users", get(list_users))
+        .route("/users/{user_id}", get(get_user).delete(delete_user))
+        .route("/users/{user_id}/patch", patch(update_user))
+        .route("/users/{user_id}/permissions", get(get_user_permissions))
+        .route("/users/roles", post(assign_role).delete(remove_role))
+}
+
+async fn require_perm(state: &AppState, user_id: Uuid, perm: &str) -> Result<(), AppError> {
+    let has = Permission::user_has_permission(&state.pool, user_id, perm)
+        .await
+        .map_err(|_| AppError::Internal("Permission check failed.".to_string()))?;
+    if !has {
+        return Err(AppError::Forbidden(format!("Permission '{}' is required.", perm)));
+    }
+    Ok(())
+}
+
+async fn list_roles(
+    State(state): State<AppState>,
+    user: CurrentUser,
+) -> Result<Json<Vec<RoleResponse>>, AppError> {
+    require_perm(&state, user.0.id, "roles.manage").await?;
+    let roles = Role::all(&state.pool).await?;
+    Ok(Json(roles.into_iter().map(|r| RoleResponse {
+        id: r.id,
+        name: r.name,
+        created_at: r.created_at,
+    }).collect()))
+}
+
+async fn list_permissions(
+    State(state): State<AppState>,
+    user: CurrentUser,
+) -> Result<Json<Vec<PermissionResponse>>, AppError> {
+    require_perm(&state, user.0.id, "roles.manage").await?;
+    let perms = Permission::all(&state.pool).await?;
+    Ok(Json(perms.into_iter().map(|p| PermissionResponse {
+        id: p.id, name: p.name, description: p.description, created_at: p.created_at,
+    }).collect()))
+}
+
+async fn get_role_permissions(
+    State(state): State<AppState>,
+    user: CurrentUser,
+    Path(role_id): Path<Uuid>,
+) -> Result<Json<Vec<PermissionResponse>>, AppError> {
+    require_perm(&state, user.0.id, "roles.manage").await?;
+    let perms = Permission::find_by_role_id(&state.pool, role_id).await?;
+    Ok(Json(perms.into_iter().map(|p| PermissionResponse {
+        id: p.id, name: p.name, description: p.description, created_at: p.created_at,
+    }).collect()))
+}
+
+async fn assign_permission(
+    State(state): State<AppState>,
+    user: CurrentUser,
+    Json(payload): Json<RolePermissionRequest>,
+) -> Result<Json<MessageResponse>, AppError> {
+    require_perm(&state, user.0.id, "roles.manage").await?;
+    Permission::assign_to_role(&state.pool, payload.role_id, payload.permission_id).await?;
+    Ok(Json(MessageResponse { data: MessageData { message: "Permission assigned to role.".to_string() } }))
+}
+
+async fn remove_permission(
+    State(state): State<AppState>,
+    user: CurrentUser,
+    Json(payload): Json<RolePermissionRequest>,
+) -> Result<Json<MessageResponse>, AppError> {
+    require_perm(&state, user.0.id, "roles.manage").await?;
+    Permission::remove_from_role(&state.pool, payload.role_id, payload.permission_id).await?;
+    Ok(Json(MessageResponse { data: MessageData { message: "Permission removed from role.".to_string() } }))
+}
+
+async fn list_users(
+    State(state): State<AppState>,
+    user: CurrentUser,
+) -> Result<Json<Vec<UserResponse>>, AppError> {
+    require_perm(&state, user.0.id, "users.read").await?;
+    let users = sqlx::query_as::<_, User>(
+        "SELECT id, email, password_hash, first_name, last_name, is_active, is_verified, created_at, updated_at FROM users ORDER BY created_at DESC"
+    ).fetch_all(&state.pool).await?;
+    Ok(Json(users.iter().map(|u| crate::schema::UserResponseData::from(u).into()).collect()))
+}
+
+async fn get_user(
+    State(state): State<AppState>,
+    user: CurrentUser,
+    Path(user_id): Path<Uuid>,
+) -> Result<Json<UserResponse>, AppError> {
+    require_perm(&state, user.0.id, "users.read").await?;
+    let found = User::find_active_by_id(&state.pool, user_id).await?.ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
+    Ok(Json(UserResponse { data: crate::schema::UserResponseData::from(&found) }))
+}
+
+async fn update_user(
+    State(state): State<AppState>,
+    user: CurrentUser,
+    Path(user_id): Path<Uuid>,
+    Json(payload): Json<UserUpdateRequest>,
+) -> Result<Json<UserResponse>, AppError> {
+    require_perm(&state, user.0.id, "users.write").await?;
+    let mut found = User::find_active_by_id(&state.pool, user_id).await?.ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
+    if let Some(ref first_name) = payload.first_name { found.first_name = first_name.clone(); }
+    if let Some(ref last_name) = payload.last_name { found.last_name = last_name.clone(); }
+    if let Some(is_active) = payload.is_active {
+        sqlx::query("UPDATE users SET is_active = $1, updated_at = NOW() WHERE id = $2")
+            .bind(is_active).bind(user_id).execute(&state.pool).await?;
+    }
+    sqlx::query("UPDATE users SET first_name = $1, last_name = $2, updated_at = NOW() WHERE id = $3")
+        .bind(&found.first_name).bind(&found.last_name).bind(user_id)
+        .execute(&state.pool).await?;
+    let updated = User::find_active_by_id(&state.pool, user_id).await?.ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
+    Ok(Json(UserResponse { data: crate::schema::UserResponseData::from(&updated) }))
+}
+
+async fn delete_user(
+    State(state): State<AppState>,
+    user: CurrentUser,
+    Path(user_id): Path<Uuid>,
+) -> Result<Json<MessageResponse>, AppError> {
+    require_perm(&state, user.0.id, "users.delete").await?;
+    let _ = User::find_active_by_id(&state.pool, user_id).await?.ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
+    sqlx::query("DELETE FROM users WHERE id = $1").bind(user_id).execute(&state.pool).await?;
+    Ok(Json(MessageResponse { data: MessageData { message: "User deleted.".to_string() } }))
+}
+
+async fn get_user_permissions(
+    State(state): State<AppState>,
+    user: CurrentUser,
+    Path(target_user_id): Path<Uuid>,
+) -> Result<Json<Vec<PermissionResponse>>, AppError> {
+    require_perm(&state, user.0.id, "users.read").await?;
+    let perms = Permission::find_by_user_id(&state.pool, target_user_id).await?;
+    Ok(Json(perms.into_iter().map(|p| PermissionResponse {
+        id: p.id, name: p.name, description: p.description, created_at: p.created_at,
+    }).collect()))
+}
+
+async fn assign_role(
+    State(state): State<AppState>,
+    user: CurrentUser,
+    Json(payload): Json<UserRoleRequest>,
+) -> Result<Json<MessageResponse>, AppError> {
+    require_perm(&state, user.0.id, "roles.manage").await?;
+    UserRoleModel::assign(&state.pool, payload.user_id, payload.role_id).await?;
+    Ok(Json(MessageResponse { data: MessageData { message: "Role assigned to user.".to_string() } }))
+}
+
+async fn remove_role(
+    State(state): State<AppState>,
+    user: CurrentUser,
+    Json(payload): Json<UserRoleRequest>,
+) -> Result<Json<MessageResponse>, AppError> {
+    require_perm(&state, user.0.id, "roles.manage").await?;
+    UserRoleModel::remove(&state.pool, payload.user_id, payload.role_id).await?;
+    Ok(Json(MessageResponse { data: MessageData { message: "Role removed from user.".to_string() } }))
+}
+
+impl From<crate::schema::UserResponseData> for UserResponse {
+    fn from(data: crate::schema::UserResponseData) -> Self {
+        Self { data }
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct RoleResponse {
+    pub id: Uuid,
+    pub name: String,
+    pub created_at: DateTime<Utc>,
+}

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -9,9 +9,9 @@ use crate::{
     errors::AppError,
     middleware::auth::CurrentUser,
     schema::{
-        AuthUserEnvelope, AuthUserResponse, ForgotPasswordRequest, LoginRequest, LogoutRequest,
-        MessageData, MessageResponse, RefreshTokenRequest, RegisterRequest, ResetPasswordRequest,
-        TokenResponse, UserResponse, UserResponseData, VerifyEmailRequest,
+        ApiResponse, AuthUserEnvelope, ForgotPasswordRequest, LoginRequest, LogoutRequest,
+        MessageData, RefreshTokenRequest, RegisterRequest, ResetPasswordRequest, TokenData,
+        UserResponseData, VerifyEmailRequest,
     },
     services::auth::AuthService,
     AppState,
@@ -32,15 +32,15 @@ pub fn router() -> Router<AppState> {
 pub async fn register(
     State(state): State<AppState>,
     Json(payload): Json<RegisterRequest>,
-) -> Result<(axum::http::StatusCode, Json<AuthUserResponse>), AppError> {
+) -> Result<(axum::http::StatusCode, Json<ApiResponse<AuthUserEnvelope>>), AppError> {
     payload.validate()?;
 
     let user = AuthService::new(state).register(payload).await?;
     Ok((
         axum::http::StatusCode::CREATED,
-        Json(AuthUserResponse {
+        Json(ApiResponse {
             data: AuthUserEnvelope {
-                user: UserResponseData::from(user),
+                user,
                 message: "Registration successful. Verification email sent.".to_string(),
             },
         }),
@@ -50,21 +50,21 @@ pub async fn register(
 pub async fn login(
     State(state): State<AppState>,
     Json(payload): Json<LoginRequest>,
-) -> Result<Json<TokenResponse>, AppError> {
+) -> Result<Json<ApiResponse<TokenData>>, AppError> {
     payload.validate()?;
     let data = AuthService::new(state).login(payload).await?;
-    Ok(Json(TokenResponse { data }))
+    Ok(Json(ApiResponse { data }))
 }
 
 pub async fn logout(
     State(state): State<AppState>,
     Json(payload): Json<LogoutRequest>,
-) -> Result<Json<MessageResponse>, AppError> {
+) -> Result<Json<ApiResponse<MessageData>>, AppError> {
     payload.validate()?;
     AuthService::new(state)
         .logout(&payload.refresh_token)
         .await?;
-    Ok(Json(MessageResponse {
+    Ok(Json(ApiResponse {
         data: MessageData {
             message: "Logout successful.".to_string(),
         },
@@ -74,29 +74,27 @@ pub async fn logout(
 pub async fn refresh(
     State(state): State<AppState>,
     Json(payload): Json<RefreshTokenRequest>,
-) -> Result<Json<TokenResponse>, AppError> {
+) -> Result<Json<ApiResponse<TokenData>>, AppError> {
     payload.validate()?;
     let data = AuthService::new(state)
         .refresh(&payload.refresh_token)
         .await?;
-    Ok(Json(TokenResponse { data }))
+    Ok(Json(ApiResponse { data }))
 }
 
-pub async fn me(current_user: CurrentUser) -> Result<Json<UserResponse>, AppError> {
-    Ok(Json(UserResponse {
-        data: UserResponseData::from(current_user.0),
+pub async fn me(current_user: CurrentUser) -> Result<Json<ApiResponse<UserResponseData>>, AppError> {
+    Ok(Json(ApiResponse {
+        data: current_user.into_response(),
     }))
 }
 
 pub async fn verify_email(
     State(state): State<AppState>,
     Json(payload): Json<VerifyEmailRequest>,
-) -> Result<Json<MessageResponse>, AppError> {
+) -> Result<Json<ApiResponse<MessageData>>, AppError> {
     payload.validate()?;
-    AuthService::new(state)
-        .verify_email(&payload.token)
-        .await?;
-    Ok(Json(MessageResponse {
+    AuthService::new(state).verify_email(&payload.token).await?;
+    Ok(Json(ApiResponse {
         data: MessageData {
             message: "Email verified successfully.".to_string(),
         },
@@ -106,12 +104,12 @@ pub async fn verify_email(
 pub async fn forgot_password(
     State(state): State<AppState>,
     Json(payload): Json<ForgotPasswordRequest>,
-) -> Result<Json<MessageResponse>, AppError> {
+) -> Result<Json<ApiResponse<MessageData>>, AppError> {
     payload.validate()?;
     AuthService::new(state)
         .forgot_password(&payload.email)
         .await?;
-    Ok(Json(MessageResponse {
+    Ok(Json(ApiResponse {
         data: MessageData {
             message: "If an account with that email exists, a reset link has been sent.".to_string(),
         },
@@ -121,12 +119,12 @@ pub async fn forgot_password(
 pub async fn reset_password(
     State(state): State<AppState>,
     Json(payload): Json<ResetPasswordRequest>,
-) -> Result<Json<MessageResponse>, AppError> {
+) -> Result<Json<ApiResponse<MessageData>>, AppError> {
     payload.validate()?;
     AuthService::new(state)
         .reset_password(&payload.token, &payload.new_password)
         .await?;
-    Ok(Json(MessageResponse {
+    Ok(Json(ApiResponse {
         data: MessageData {
             message: "Password reset successfully.".to_string(),
         },

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -9,9 +9,9 @@ use crate::{
     errors::AppError,
     middleware::auth::CurrentUser,
     schema::{
-        AuthUserEnvelope, AuthUserResponse, LoginRequest, LogoutRequest, MessageData,
-        MessageResponse, RefreshTokenRequest, RegisterRequest, TokenResponse, UserResponse,
-        UserResponseData,
+        AuthUserEnvelope, AuthUserResponse, ForgotPasswordRequest, LoginRequest, LogoutRequest,
+        MessageData, MessageResponse, RefreshTokenRequest, RegisterRequest, ResetPasswordRequest,
+        TokenResponse, UserResponse, UserResponseData, VerifyEmailRequest,
     },
     services::auth::AuthService,
     AppState,
@@ -24,6 +24,9 @@ pub fn router() -> Router<AppState> {
         .route("/logout", post(logout))
         .route("/refresh", post(refresh))
         .route("/me", get(me))
+        .route("/verify-email", post(verify_email))
+        .route("/forgot-password", post(forgot_password))
+        .route("/reset-password", post(reset_password))
 }
 
 pub async fn register(
@@ -82,5 +85,50 @@ pub async fn refresh(
 pub async fn me(current_user: CurrentUser) -> Result<Json<UserResponse>, AppError> {
     Ok(Json(UserResponse {
         data: UserResponseData::from(current_user.0),
+    }))
+}
+
+pub async fn verify_email(
+    State(state): State<AppState>,
+    Json(payload): Json<VerifyEmailRequest>,
+) -> Result<Json<MessageResponse>, AppError> {
+    payload.validate()?;
+    AuthService::new(state)
+        .verify_email(&payload.token)
+        .await?;
+    Ok(Json(MessageResponse {
+        data: MessageData {
+            message: "Email verified successfully.".to_string(),
+        },
+    }))
+}
+
+pub async fn forgot_password(
+    State(state): State<AppState>,
+    Json(payload): Json<ForgotPasswordRequest>,
+) -> Result<Json<MessageResponse>, AppError> {
+    payload.validate()?;
+    AuthService::new(state)
+        .forgot_password(&payload.email)
+        .await?;
+    Ok(Json(MessageResponse {
+        data: MessageData {
+            message: "If an account with that email exists, a reset link has been sent.".to_string(),
+        },
+    }))
+}
+
+pub async fn reset_password(
+    State(state): State<AppState>,
+    Json(payload): Json<ResetPasswordRequest>,
+) -> Result<Json<MessageResponse>, AppError> {
+    payload.validate()?;
+    AuthService::new(state)
+        .reset_password(&payload.token, &payload.new_password)
+        .await?;
+    Ok(Json(MessageResponse {
+        data: MessageData {
+            message: "Password reset successfully.".to_string(),
+        },
     }))
 }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,2 +1,3 @@
+pub mod admin;
 pub mod auth;
 pub mod health;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ mod schema;
 mod services;
 
 use config::AppConfig;
-use handlers::{auth::router as auth_router, health::health_check};
+use handlers::{admin, auth::router as auth_router, health::health_check};
 use mailer::Mailer;
 use services::token::TokenService;
 
@@ -47,6 +47,7 @@ async fn main() -> anyhow::Result<()> {
     let app = Router::new()
         .route("/health", get(health_check))
         .nest("/api/v1/auth", auth_router())
+        .nest("/api/v1/admin", admin::router())
         .with_state(state);
 
     let bind_port = if config.app.port == 8003 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ async fn main() -> anyhow::Result<()> {
     let app = Router::new()
         .route("/health", get(health_check))
         .nest("/api/v1/auth", auth_router())
-        .nest("/api/v1/admin", admin::router())
+        .merge(admin::router())
         .with_state(state);
 
     let bind_port = if config.app.port == 8003 {

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -1,20 +1,41 @@
-use std::ops::Deref;
-
 use axum::{
     extract::FromRequestParts,
     http::{header, request::Parts},
 };
 use uuid::Uuid;
 
-use crate::{errors::AppError, models::user::User, AppState};
+use crate::{
+    errors::AppError,
+    models::{permission::Permission, role::Role, user::User},
+    schema::UserResponseData,
+    AppState,
+};
 
-pub struct CurrentUser(pub User);
+#[derive(Clone, Debug)]
+pub struct CurrentUser {
+    pub user: User,
+    pub roles: Vec<Role>,
+    pub permissions: Vec<Permission>,
+}
 
-impl Deref for CurrentUser {
-    type Target = User;
+impl CurrentUser {
+    pub fn require(&self, permission_name: &str) -> Result<(), AppError> {
+        if self
+            .permissions
+            .iter()
+            .any(|permission| permission.name == permission_name)
+        {
+            Ok(())
+        } else {
+            Err(AppError::Forbidden(format!(
+                "Permission '{}' is required.",
+                permission_name
+            )))
+        }
+    }
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    pub fn into_response(self) -> UserResponseData {
+        UserResponseData::from_parts(self.user, self.roles, self.permissions)
     }
 }
 
@@ -48,7 +69,13 @@ impl FromRequestParts<AppState> for CurrentUser {
             .ok_or_else(|| {
                 AppError::Unauthorized("Authenticated user was not found.".to_string())
             })?;
+        let roles = Role::find_by_user_id(&state.pool, user_id).await?;
+        let permissions = Permission::find_by_user_id(&state.pool, user_id).await?;
 
-        Ok(Self(user))
+        Ok(Self {
+            user,
+            roles,
+            permissions,
+        })
     }
 }

--- a/src/models/email_verification_token.rs
+++ b/src/models/email_verification_token.rs
@@ -1,0 +1,74 @@
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[allow(dead_code)]
+#[derive(Clone, Debug, sqlx::FromRow)]
+pub struct EmailVerificationToken {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub token_hash: String,
+    pub expires_at: DateTime<Utc>,
+    pub used_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+}
+
+impl EmailVerificationToken {
+    pub async fn create(
+        pool: &PgPool,
+        user_id: Uuid,
+        token_hash: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<Self, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            INSERT INTO email_verification_tokens (user_id, token_hash, expires_at)
+            VALUES ($1, $2, $3)
+            RETURNING id, user_id, token_hash, expires_at, used_at, created_at
+            "#,
+        )
+        .bind(user_id)
+        .bind(token_hash)
+        .bind(expires_at)
+        .fetch_one(pool)
+        .await
+    }
+
+    pub async fn invalidate_unused_for_user(pool: &PgPool, user_id: Uuid) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "UPDATE email_verification_tokens SET used_at = NOW() WHERE user_id = $1 AND used_at IS NULL",
+        )
+        .bind(user_id)
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn find_active_by_hash(
+        pool: &PgPool,
+        token_hash: &str,
+    ) -> Result<Option<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            SELECT id, user_id, token_hash, expires_at, used_at, created_at
+            FROM email_verification_tokens
+            WHERE token_hash = $1 AND used_at IS NULL AND expires_at > NOW()
+            ORDER BY created_at DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(token_hash)
+        .fetch_optional(pool)
+        .await
+    }
+
+    pub async fn mark_used(pool: &PgPool, token_id: Uuid) -> Result<(), sqlx::Error> {
+        sqlx::query("UPDATE email_verification_tokens SET used_at = NOW() WHERE id = $1")
+            .bind(token_id)
+            .execute(pool)
+            .await?;
+
+        Ok(())
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,5 @@
+pub mod permission;
 pub mod refresh_token;
 pub mod role;
 pub mod user;
+pub mod user_role;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,4 +1,6 @@
+pub mod email_verification_token;
 pub mod permission;
+pub mod password_reset_token;
 pub mod refresh_token;
 pub mod role;
 pub mod user;

--- a/src/models/password_reset_token.rs
+++ b/src/models/password_reset_token.rs
@@ -1,0 +1,74 @@
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[allow(dead_code)]
+#[derive(Clone, Debug, sqlx::FromRow)]
+pub struct PasswordResetToken {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub token_hash: String,
+    pub expires_at: DateTime<Utc>,
+    pub used_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+}
+
+impl PasswordResetToken {
+    pub async fn create(
+        pool: &PgPool,
+        user_id: Uuid,
+        token_hash: &str,
+        expires_at: DateTime<Utc>,
+    ) -> Result<Self, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            INSERT INTO password_reset_tokens (user_id, token_hash, expires_at)
+            VALUES ($1, $2, $3)
+            RETURNING id, user_id, token_hash, expires_at, used_at, created_at
+            "#,
+        )
+        .bind(user_id)
+        .bind(token_hash)
+        .bind(expires_at)
+        .fetch_one(pool)
+        .await
+    }
+
+    pub async fn invalidate_unused_for_user(pool: &PgPool, user_id: Uuid) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "UPDATE password_reset_tokens SET used_at = NOW() WHERE user_id = $1 AND used_at IS NULL",
+        )
+        .bind(user_id)
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn find_active_by_hash(
+        pool: &PgPool,
+        token_hash: &str,
+    ) -> Result<Option<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            SELECT id, user_id, token_hash, expires_at, used_at, created_at
+            FROM password_reset_tokens
+            WHERE token_hash = $1 AND used_at IS NULL AND expires_at > NOW()
+            ORDER BY created_at DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(token_hash)
+        .fetch_optional(pool)
+        .await
+    }
+
+    pub async fn mark_used(pool: &PgPool, token_id: Uuid) -> Result<(), sqlx::Error> {
+        sqlx::query("UPDATE password_reset_tokens SET used_at = NOW() WHERE id = $1")
+            .bind(token_id)
+            .execute(pool)
+            .await?;
+
+        Ok(())
+    }
+}

--- a/src/models/permission.rs
+++ b/src/models/permission.rs
@@ -1,0 +1,91 @@
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, sqlx::FromRow)]
+pub struct Permission {
+    pub id: Uuid,
+    pub name: String,
+    pub description: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl Permission {
+    pub async fn all(pool: &PgPool) -> Result<Vec<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>("SELECT id, name, description, created_at FROM permissions ORDER BY name")
+            .fetch_all(pool)
+            .await
+    }
+
+    pub async fn find_by_name(pool: &PgPool, name: &str) -> Result<Option<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>("SELECT id, name, description, created_at FROM permissions WHERE name = $1")
+            .bind(name)
+            .fetch_optional(pool)
+            .await
+    }
+
+    pub async fn find_by_user_id(pool: &PgPool, user_id: Uuid) -> Result<Vec<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            SELECT p.id, p.name, p.description, p.created_at
+            FROM permissions p
+            JOIN role_permissions rp ON rp.permission_id = p.id
+            JOIN user_roles ur ON ur.role_id = rp.role_id
+            WHERE ur.user_id = $1
+            "#,
+        )
+        .bind(user_id)
+        .fetch_all(pool)
+        .await
+    }
+
+    pub async fn user_has_permission(pool: &PgPool, user_id: Uuid, permission_name: &str) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query_scalar::<_, bool>(
+            r#"
+            SELECT EXISTS(
+                SELECT 1 FROM permissions p
+                JOIN role_permissions rp ON rp.permission_id = p.id
+                JOIN user_roles ur ON ur.role_id = rp.role_id
+                WHERE ur.user_id = $1 AND p.name = $2
+            )
+            "#,
+        )
+        .bind(user_id)
+        .bind(permission_name)
+        .fetch_one(pool)
+        .await?;
+        Ok(result)
+    }
+
+    pub async fn find_by_role_id(pool: &PgPool, role_id: Uuid) -> Result<Vec<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            SELECT p.id, p.name, p.description, p.created_at
+            FROM permissions p
+            JOIN role_permissions rp ON rp.permission_id = p.id
+            WHERE rp.role_id = $1
+            "#,
+        )
+        .bind(role_id)
+        .fetch_all(pool)
+        .await
+    }
+
+    pub async fn assign_to_role(pool: &PgPool, role_id: Uuid, permission_id: Uuid) -> Result<(), sqlx::Error> {
+        sqlx::query("INSERT INTO role_permissions (role_id, permission_id) VALUES ($1, $2) ON CONFLICT DO NOTHING")
+            .bind(role_id)
+            .bind(permission_id)
+            .execute(pool)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn remove_from_role(pool: &PgPool, role_id: Uuid, permission_id: Uuid) -> Result<(), sqlx::Error> {
+        sqlx::query("DELETE FROM role_permissions WHERE role_id = $1 AND permission_id = $2")
+            .bind(role_id)
+            .bind(permission_id)
+            .execute(pool)
+            .await?;
+        Ok(())
+    }
+}

--- a/src/models/permission.rs
+++ b/src/models/permission.rs
@@ -17,6 +17,32 @@ impl Permission {
             .await
     }
 
+    pub async fn create(
+        pool: &PgPool,
+        name: &str,
+        description: &str,
+    ) -> Result<Self, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            "INSERT INTO permissions (name, description) VALUES ($1, $2) RETURNING id, name, description, created_at",
+        )
+        .bind(name)
+        .bind(description)
+        .fetch_one(pool)
+        .await
+    }
+
+    pub async fn find_by_id(
+        pool: &PgPool,
+        permission_id: Uuid,
+    ) -> Result<Option<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            "SELECT id, name, description, created_at FROM permissions WHERE id = $1",
+        )
+        .bind(permission_id)
+        .fetch_optional(pool)
+        .await
+    }
+
     pub async fn find_by_name(pool: &PgPool, name: &str) -> Result<Option<Self>, sqlx::Error> {
         sqlx::query_as::<_, Self>("SELECT id, name, description, created_at FROM permissions WHERE name = $1")
             .bind(name)
@@ -27,34 +53,17 @@ impl Permission {
     pub async fn find_by_user_id(pool: &PgPool, user_id: Uuid) -> Result<Vec<Self>, sqlx::Error> {
         sqlx::query_as::<_, Self>(
             r#"
-            SELECT p.id, p.name, p.description, p.created_at
+            SELECT DISTINCT p.id, p.name, p.description, p.created_at
             FROM permissions p
             JOIN role_permissions rp ON rp.permission_id = p.id
             JOIN user_roles ur ON ur.role_id = rp.role_id
             WHERE ur.user_id = $1
+            ORDER BY p.name
             "#,
         )
         .bind(user_id)
         .fetch_all(pool)
         .await
-    }
-
-    pub async fn user_has_permission(pool: &PgPool, user_id: Uuid, permission_name: &str) -> Result<bool, sqlx::Error> {
-        let result = sqlx::query_scalar::<_, bool>(
-            r#"
-            SELECT EXISTS(
-                SELECT 1 FROM permissions p
-                JOIN role_permissions rp ON rp.permission_id = p.id
-                JOIN user_roles ur ON ur.role_id = rp.role_id
-                WHERE ur.user_id = $1 AND p.name = $2
-            )
-            "#,
-        )
-        .bind(user_id)
-        .bind(permission_name)
-        .fetch_one(pool)
-        .await?;
-        Ok(result)
     }
 
     pub async fn find_by_role_id(pool: &PgPool, role_id: Uuid) -> Result<Vec<Self>, sqlx::Error> {
@@ -64,11 +73,37 @@ impl Permission {
             FROM permissions p
             JOIN role_permissions rp ON rp.permission_id = p.id
             WHERE rp.role_id = $1
+            ORDER BY p.name
             "#,
         )
         .bind(role_id)
         .fetch_all(pool)
         .await
+    }
+
+    pub async fn update(
+        pool: &PgPool,
+        permission_id: Uuid,
+        name: &str,
+        description: &str,
+    ) -> Result<Self, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            "UPDATE permissions SET name = $1, description = $2 WHERE id = $3 RETURNING id, name, description, created_at",
+        )
+        .bind(name)
+        .bind(description)
+        .bind(permission_id)
+        .fetch_one(pool)
+        .await
+    }
+
+    pub async fn delete(pool: &PgPool, permission_id: Uuid) -> Result<(), sqlx::Error> {
+        sqlx::query("DELETE FROM permissions WHERE id = $1")
+            .bind(permission_id)
+            .execute(pool)
+            .await?;
+
+        Ok(())
     }
 
     pub async fn assign_to_role(pool: &PgPool, role_id: Uuid, permission_id: Uuid) -> Result<(), sqlx::Error> {

--- a/src/models/refresh_token.rs
+++ b/src/models/refresh_token.rs
@@ -59,4 +59,13 @@ impl RefreshToken {
             .await?;
         Ok(())
     }
+
+    pub async fn revoke_all_for_user(pool: &PgPool, user_id: Uuid) -> Result<(), sqlx::Error> {
+        sqlx::query("UPDATE refresh_tokens SET revoked_at = NOW() WHERE user_id = $1 AND revoked_at IS NULL")
+            .bind(user_id)
+            .execute(pool)
+            .await?;
+
+        Ok(())
+    }
 }

--- a/src/models/role.rs
+++ b/src/models/role.rs
@@ -2,7 +2,6 @@ use chrono::{DateTime, Utc};
 use sqlx::PgPool;
 use uuid::Uuid;
 
-#[allow(dead_code)]
 #[derive(Clone, Debug, sqlx::FromRow)]
 pub struct Role {
     pub id: Uuid,
@@ -10,11 +9,67 @@ pub struct Role {
     pub created_at: DateTime<Utc>,
 }
 
-#[allow(dead_code)]
 impl Role {
     pub async fn all(pool: &PgPool) -> Result<Vec<Self>, sqlx::Error> {
         sqlx::query_as::<_, Self>("SELECT id, name, created_at FROM roles ORDER BY name")
             .fetch_all(pool)
             .await
+    }
+
+    pub async fn create(pool: &PgPool, name: &str) -> Result<Self, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            "INSERT INTO roles (name) VALUES ($1) RETURNING id, name, created_at",
+        )
+        .bind(name)
+        .fetch_one(pool)
+        .await
+    }
+
+    pub async fn find_by_id(pool: &PgPool, role_id: Uuid) -> Result<Option<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>("SELECT id, name, created_at FROM roles WHERE id = $1")
+            .bind(role_id)
+            .fetch_optional(pool)
+            .await
+    }
+
+    pub async fn find_by_name(pool: &PgPool, name: &str) -> Result<Option<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>("SELECT id, name, created_at FROM roles WHERE name = $1")
+            .bind(name)
+            .fetch_optional(pool)
+            .await
+    }
+
+    pub async fn update(pool: &PgPool, role_id: Uuid, name: &str) -> Result<Self, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            "UPDATE roles SET name = $1 WHERE id = $2 RETURNING id, name, created_at",
+        )
+        .bind(name)
+        .bind(role_id)
+        .fetch_one(pool)
+        .await
+    }
+
+    pub async fn delete(pool: &PgPool, role_id: Uuid) -> Result<(), sqlx::Error> {
+        sqlx::query("DELETE FROM roles WHERE id = $1")
+            .bind(role_id)
+            .execute(pool)
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn find_by_user_id(pool: &PgPool, user_id: Uuid) -> Result<Vec<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            SELECT r.id, r.name, r.created_at
+            FROM roles r
+            INNER JOIN user_roles ur ON ur.role_id = r.id
+            WHERE ur.user_id = $1
+            ORDER BY r.name
+            "#,
+        )
+        .bind(user_id)
+        .fetch_all(pool)
+        .await
     }
 }

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -16,6 +16,12 @@ pub struct User {
 }
 
 impl User {
+    pub async fn count_all(pool: &PgPool) -> Result<i64, sqlx::Error> {
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM users")
+            .fetch_one(pool)
+            .await
+    }
+
     pub async fn create(
         pool: &PgPool,
         email: &str,
@@ -65,5 +71,68 @@ impl User {
         .bind(user_id)
         .fetch_optional(pool)
         .await
+    }
+
+    pub async fn find_by_id(pool: &PgPool, user_id: Uuid) -> Result<Option<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            SELECT id, email, password_hash, first_name, last_name, is_active, is_verified, created_at, updated_at
+            FROM users
+            WHERE id = $1
+            "#,
+        )
+        .bind(user_id)
+        .fetch_optional(pool)
+        .await
+    }
+
+    pub async fn list(pool: &PgPool) -> Result<Vec<Self>, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            SELECT id, email, password_hash, first_name, last_name, is_active, is_verified, created_at, updated_at
+            FROM users
+            ORDER BY created_at DESC
+            "#,
+        )
+        .fetch_all(pool)
+        .await
+    }
+
+    pub async fn update(
+        pool: &PgPool,
+        user_id: Uuid,
+        first_name: &str,
+        last_name: &str,
+        is_active: bool,
+        is_verified: bool,
+    ) -> Result<Self, sqlx::Error> {
+        sqlx::query_as::<_, Self>(
+            r#"
+            UPDATE users
+            SET first_name = $1,
+                last_name = $2,
+                is_active = $3,
+                is_verified = $4,
+                updated_at = NOW()
+            WHERE id = $5
+            RETURNING id, email, password_hash, first_name, last_name, is_active, is_verified, created_at, updated_at
+            "#,
+        )
+        .bind(first_name)
+        .bind(last_name)
+        .bind(is_active)
+        .bind(is_verified)
+        .bind(user_id)
+        .fetch_one(pool)
+        .await
+    }
+
+    pub async fn delete(pool: &PgPool, user_id: Uuid) -> Result<(), sqlx::Error> {
+        sqlx::query("DELETE FROM users WHERE id = $1")
+            .bind(user_id)
+            .execute(pool)
+            .await?;
+
+        Ok(())
     }
 }

--- a/src/models/user_role.rs
+++ b/src/models/user_role.rs
@@ -1,0 +1,24 @@
+use sqlx::PgPool;
+use uuid::Uuid;
+
+pub struct UserRole;
+
+impl UserRole {
+    pub async fn assign(pool: &PgPool, user_id: Uuid, role_id: Uuid) -> Result<(), sqlx::Error> {
+        sqlx::query("INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING")
+            .bind(user_id)
+            .bind(role_id)
+            .execute(pool)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn remove(pool: &PgPool, user_id: Uuid, role_id: Uuid) -> Result<(), sqlx::Error> {
+        sqlx::query("DELETE FROM user_roles WHERE user_id = $1 AND role_id = $2")
+            .bind(user_id)
+            .bind(role_id)
+            .execute(pool)
+            .await?;
+        Ok(())
+    }
+}

--- a/src/models/user_role.rs
+++ b/src/models/user_role.rs
@@ -1,3 +1,4 @@
+use crate::models::role::Role;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -20,5 +21,9 @@ impl UserRole {
             .execute(pool)
             .await?;
         Ok(())
+    }
+
+    pub async fn list_by_user_id(pool: &PgPool, user_id: Uuid) -> Result<Vec<Role>, sqlx::Error> {
+        Role::find_by_user_id(pool, user_id).await
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,9 +1,14 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use validator::Validate;
+use validator::{Validate, ValidationError};
 
-use crate::models::user::User;
+use crate::models::{permission::Permission, role::Role, user::User};
+
+#[derive(Debug, Serialize)]
+pub struct ApiResponse<T> {
+    pub data: T,
+}
 
 #[derive(Debug, Deserialize, Validate)]
 pub struct RegisterRequest {
@@ -50,23 +55,8 @@ pub struct TokenData {
 }
 
 #[derive(Debug, Serialize)]
-pub struct TokenResponse {
-    pub data: TokenData,
-}
-
-#[derive(Debug, Serialize)]
 pub struct MessageData {
     pub message: String,
-}
-
-#[derive(Debug, Serialize)]
-pub struct MessageResponse {
-    pub data: MessageData,
-}
-
-#[derive(Debug, Serialize)]
-pub struct AuthUserResponse {
-    pub data: AuthUserEnvelope,
 }
 
 #[derive(Debug, Serialize)]
@@ -75,9 +65,53 @@ pub struct AuthUserEnvelope {
     pub message: String,
 }
 
-#[derive(Debug, Serialize)]
-pub struct UserResponse {
-    pub data: UserResponseData,
+#[derive(Debug, Serialize, Clone)]
+pub struct PermissionResponseData {
+    pub id: Uuid,
+    pub name: String,
+    pub description: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl From<Permission> for PermissionResponseData {
+    fn from(permission: Permission) -> Self {
+        Self {
+            id: permission.id,
+            name: permission.name,
+            description: permission.description,
+            created_at: permission.created_at,
+        }
+    }
+}
+
+impl From<&Permission> for PermissionResponseData {
+    fn from(permission: &Permission) -> Self {
+        Self {
+            id: permission.id,
+            name: permission.name.clone(),
+            description: permission.description.clone(),
+            created_at: permission.created_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct RoleResponseData {
+    pub id: Uuid,
+    pub name: String,
+    pub created_at: DateTime<Utc>,
+    pub permissions: Vec<PermissionResponseData>,
+}
+
+impl RoleResponseData {
+    pub fn from_role(role: Role, permissions: Vec<Permission>) -> Self {
+        Self {
+            id: role.id,
+            name: role.name,
+            created_at: role.created_at,
+            permissions: permissions.iter().map(PermissionResponseData::from).collect(),
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -90,10 +124,27 @@ pub struct UserResponseData {
     pub is_verified: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub roles: Vec<RoleResponseData>,
+    pub permissions: Vec<PermissionResponseData>,
 }
 
-impl From<User> for UserResponseData {
-    fn from(user: User) -> Self {
+impl UserResponseData {
+    pub fn from_parts(user: User, roles: Vec<Role>, permissions: Vec<Permission>) -> Self {
+        let role_items = roles
+            .into_iter()
+            .map(|role| RoleResponseData {
+                id: role.id,
+                name: role.name,
+                created_at: role.created_at,
+                permissions: Vec::new(),
+            })
+            .collect();
+
+        let permission_items = permissions
+            .iter()
+            .map(PermissionResponseData::from)
+            .collect();
+
         Self {
             id: user.id,
             email: user.email,
@@ -103,21 +154,8 @@ impl From<User> for UserResponseData {
             is_verified: user.is_verified,
             created_at: user.created_at,
             updated_at: user.updated_at,
-        }
-    }
-}
-
-impl From<&User> for UserResponseData {
-    fn from(user: &User) -> Self {
-        Self {
-            id: user.id,
-            email: user.email.clone(),
-            first_name: user.first_name.clone(),
-            last_name: user.last_name.clone(),
-            is_active: user.is_active,
-            is_verified: user.is_verified,
-            created_at: user.created_at,
-            updated_at: user.updated_at,
+            roles: role_items,
+            permissions: permission_items,
         }
     }
 }
@@ -138,33 +176,98 @@ pub struct ForgotPasswordRequest {
 pub struct ResetPasswordRequest {
     #[validate(length(min = 1, message = "Token is required."))]
     pub token: String,
-    #[validate(length(min = 8, max = 128, message = "Password must be between 8 and 128 characters."))]
+    #[validate(length(
+        min = 8,
+        max = 128,
+        message = "Password must be between 8 and 128 characters."
+    ))]
     pub new_password: String,
 }
 
-#[derive(Debug, Serialize)]
-pub struct PermissionResponse {
-    pub id: Uuid,
+#[derive(Debug, Deserialize, Validate)]
+pub struct CreateRoleRequest {
+    #[validate(length(min = 1, max = 50, message = "Role name is required."))]
     pub name: String,
-    pub description: String,
-    pub created_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct RolePermissionRequest {
-    pub role_id: Uuid,
+#[derive(Debug, Deserialize, Validate)]
+pub struct UpdateRoleRequest {
+    #[validate(length(min = 1, max = 50, message = "Role name is required."))]
+    pub name: String,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+pub struct CreatePermissionRequest {
+    #[validate(custom(function = "validate_permission_name"))]
+    pub name: String,
+    #[validate(length(min = 1, max = 255, message = "Description is required."))]
+    pub description: String,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+pub struct UpdatePermissionRequest {
+    #[validate(custom(function = "validate_permission_name"))]
+    pub name: String,
+    #[validate(length(min = 1, max = 255, message = "Description is required."))]
+    pub description: String,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+pub struct AssignPermissionRequest {
     pub permission_id: Uuid,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct UserRoleRequest {
-    pub user_id: Uuid,
+#[derive(Debug, Deserialize, Validate)]
+pub struct AssignRoleRequest {
     pub role_id: Uuid,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct UserUpdateRequest {
+#[derive(Debug, Deserialize, Validate)]
+pub struct CreateUserRequest {
+    #[validate(email(message = "Email must be valid."))]
+    pub email: String,
+    #[validate(length(
+        min = 8,
+        max = 128,
+        message = "Password must be between 8 and 128 characters."
+    ))]
+    pub password: String,
+    #[validate(length(min = 1, max = 100, message = "First name is required."))]
+    pub first_name: String,
+    #[validate(length(min = 1, max = 100, message = "Last name is required."))]
+    pub last_name: String,
+    pub is_active: Option<bool>,
+    pub is_verified: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+pub struct UpdateUserRequest {
+    #[validate(length(min = 1, max = 100, message = "First name is required."))]
     pub first_name: Option<String>,
+    #[validate(length(min = 1, max = 100, message = "Last name is required."))]
     pub last_name: Option<String>,
     pub is_active: Option<bool>,
+    pub is_verified: Option<bool>,
+}
+
+fn validate_permission_name(name: &str) -> Result<(), ValidationError> {
+    let is_valid = name
+        .split_once(':')
+        .map(|(resource, action)| {
+            !resource.is_empty()
+                && !action.is_empty()
+                && resource
+                    .chars()
+                    .all(|character| character.is_ascii_lowercase() || character == '_')
+                && action
+                    .chars()
+                    .all(|character| character.is_ascii_lowercase() || character == '_')
+        })
+        .unwrap_or(false);
+
+    if is_valid {
+        Ok(())
+    } else {
+        Err(ValidationError::new("permission_format"))
+    }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -121,3 +121,23 @@ impl From<&User> for UserResponseData {
         }
     }
 }
+
+#[derive(Debug, Deserialize, Validate)]
+pub struct VerifyEmailRequest {
+    #[validate(length(min = 1, message = "Token is required."))]
+    pub token: String,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+pub struct ForgotPasswordRequest {
+    #[validate(email(message = "Email must be valid."))]
+    pub email: String,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+pub struct ResetPasswordRequest {
+    #[validate(length(min = 1, message = "Token is required."))]
+    pub token: String,
+    #[validate(length(min = 8, max = 128, message = "Password must be between 8 and 128 characters."))]
+    pub new_password: String,
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -141,3 +141,30 @@ pub struct ResetPasswordRequest {
     #[validate(length(min = 8, max = 128, message = "Password must be between 8 and 128 characters."))]
     pub new_password: String,
 }
+
+#[derive(Debug, Serialize)]
+pub struct PermissionResponse {
+    pub id: Uuid,
+    pub name: String,
+    pub description: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RolePermissionRequest {
+    pub role_id: Uuid,
+    pub permission_id: Uuid,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UserRoleRequest {
+    pub user_id: Uuid,
+    pub role_id: Uuid,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UserUpdateRequest {
+    pub first_name: Option<String>,
+    pub last_name: Option<String>,
+    pub is_active: Option<bool>,
+}

--- a/src/services/auth.rs
+++ b/src/services/auth.rs
@@ -149,3 +149,71 @@ impl AuthService {
 fn parse_uuid(value: &str) -> Result<Uuid, AppError> {
     Uuid::parse_str(value).map_err(|_| AppError::Unauthorized("Invalid token subject.".to_string()))
 }
+
+impl AuthService {
+    pub async fn verify_email(&self, token: &str) -> Result<(), AppError> {
+        let claims = self
+            .state
+            .token_service
+            .decode_token(token, "verification")?;
+        let user_id = parse_uuid(&claims.sub)?;
+        let user = User::find_active_by_id(&self.state.pool, user_id)
+            .await?
+            .ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
+
+        if user.is_verified {
+            return Err(AppError::BadRequest("Email is already verified.".to_string()));
+        }
+
+        sqlx::query("UPDATE users SET is_verified = true, updated_at = NOW() WHERE id = $1")
+            .bind(user_id)
+            .execute(&self.state.pool)
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn forgot_password(&self, email: &str) -> Result<(), AppError> {
+        let email = email.trim().to_lowercase();
+        let user = match User::find_by_email(&self.state.pool, &email).await? {
+            Some(u) => u,
+            None => return Ok(()),
+        };
+
+        let reset_token = self
+            .state
+            .token_service
+            .create_verification_token(user.id, &user.email)?;
+
+        self.state
+            .mailer
+            .send_email(
+                &user.email,
+                "Password Reset",
+                &format!("Your password reset token is: {}", reset_token),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn reset_password(&self, token: &str, new_password: &str) -> Result<(), AppError> {
+        let claims = self
+            .state
+            .token_service
+            .decode_token(token, "verification")?;
+        let user_id = parse_uuid(&claims.sub)?;
+        let user = User::find_active_by_id(&self.state.pool, user_id)
+            .await?
+            .ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
+
+        let password_hash = self.hash_password(new_password)?;
+        sqlx::query("UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2")
+            .bind(&password_hash)
+            .bind(user.id)
+            .execute(&self.state.pool)
+            .await?;
+
+        Ok(())
+    }
+}

--- a/src/services/auth.rs
+++ b/src/services/auth.rs
@@ -6,8 +6,12 @@ use uuid::Uuid;
 
 use crate::{
     errors::AppError,
-    models::{refresh_token::RefreshToken, user::User},
-    schema::{LoginRequest, RegisterRequest, TokenData},
+    models::{
+        email_verification_token::EmailVerificationToken, password_reset_token::PasswordResetToken,
+        permission::Permission, refresh_token::RefreshToken, role::Role, user::User,
+        user_role::UserRole,
+    },
+    schema::{CreateUserRequest, LoginRequest, RegisterRequest, TokenData, UserResponseData},
     AppState,
 };
 
@@ -20,17 +24,15 @@ impl AuthService {
         Self { state }
     }
 
-    pub async fn register(&self, payload: RegisterRequest) -> Result<User, AppError> {
+    pub async fn register(&self, payload: RegisterRequest) -> Result<UserResponseData, AppError> {
         let email = payload.email.trim().to_lowercase();
-        if User::find_by_email(&self.state.pool, &email)
-            .await?
-            .is_some()
-        {
+        if User::find_by_email(&self.state.pool, &email).await?.is_some() {
             return Err(AppError::Conflict(
                 "A user with this email already exists.".to_string(),
             ));
         }
 
+        let existing_user_count = User::count_all(&self.state.pool).await?;
         let password_hash = self.hash_password(&payload.password)?;
         let user = User::create(
             &self.state.pool,
@@ -41,24 +43,55 @@ impl AuthService {
         )
         .await?;
 
-        let verification_token = self
-            .state
-            .token_service
-            .create_verification_token(user.id, &user.email)?;
+        let default_role_name = if existing_user_count == 0 {
+            "super_admin"
+        } else {
+            "user"
+        };
+        self.assign_role_by_name(user.id, default_role_name).await?;
+        self.issue_email_verification(&user).await?;
 
-        self.state
-            .mailer
-            .send_email(
-                &user.email,
-                "Verify your account",
-                &format!(
-                    "Welcome {}, your verification token is: {}",
-                    user.first_name, verification_token
-                ),
-            )
-            .await?;
+        self.build_user_response(user.id).await
+    }
 
-        Ok(user)
+    pub async fn create_user(
+        &self,
+        payload: CreateUserRequest,
+    ) -> Result<UserResponseData, AppError> {
+        let email = payload.email.trim().to_lowercase();
+        if User::find_by_email(&self.state.pool, &email).await?.is_some() {
+            return Err(AppError::Conflict(
+                "A user with this email already exists.".to_string(),
+            ));
+        }
+
+        let password_hash = self.hash_password(&payload.password)?;
+        let mut user = User::create(
+            &self.state.pool,
+            &email,
+            &password_hash,
+            payload.first_name.trim(),
+            payload.last_name.trim(),
+        )
+        .await?;
+
+        let updated_user = User::update(
+            &self.state.pool,
+            user.id,
+            &user.first_name,
+            &user.last_name,
+            payload.is_active.unwrap_or(true),
+            payload.is_verified.unwrap_or(false),
+        )
+        .await?;
+        user = updated_user;
+
+        self.assign_role_by_name(user.id, "user").await?;
+        if !user.is_verified {
+            self.issue_email_verification(&user).await?;
+        }
+
+        self.build_user_response(user.id).await
     }
 
     pub async fn login(&self, payload: LoginRequest) -> Result<TokenData, AppError> {
@@ -71,6 +104,12 @@ impl AuthService {
 
         if !user.is_active {
             return Err(AppError::Forbidden("User account is inactive.".to_string()));
+        }
+
+        if !user.is_verified {
+            return Err(AppError::Forbidden(
+                "Email address must be verified before login.".to_string(),
+            ));
         }
 
         self.issue_and_store_tokens(user.id).await
@@ -114,21 +153,90 @@ impl AuthService {
         self.issue_and_store_tokens(user_id).await
     }
 
-    async fn issue_and_store_tokens(&self, user_id: Uuid) -> Result<TokenData, AppError> {
-        let tokens = self.state.token_service.issue_token_pair(user_id)?;
-        let token_hash = self.state.token_service.hash_token(&tokens.refresh_token);
-        RefreshToken::create(
+    pub async fn verify_email(&self, token: &str) -> Result<(), AppError> {
+        let token_hash = self.state.token_service.hash_token(token);
+        let stored = EmailVerificationToken::find_active_by_hash(&self.state.pool, &token_hash)
+            .await?
+            .ok_or_else(|| AppError::Unauthorized("Verification token is invalid or expired.".to_string()))?;
+        let user = User::find_by_id(&self.state.pool, stored.user_id)
+            .await?
+            .ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
+
+        if user.is_verified {
+            return Err(AppError::BadRequest("Email is already verified.".to_string()));
+        }
+
+        sqlx::query("UPDATE users SET is_verified = true, updated_at = NOW() WHERE id = $1")
+            .bind(user.id)
+            .execute(&self.state.pool)
+            .await?;
+        EmailVerificationToken::mark_used(&self.state.pool, stored.id).await?;
+
+        Ok(())
+    }
+
+    pub async fn forgot_password(&self, email: &str) -> Result<(), AppError> {
+        let email = email.trim().to_lowercase();
+        let user = match User::find_by_email(&self.state.pool, &email).await? {
+            Some(user) if user.is_active => user,
+            Some(_) | None => return Ok(()),
+        };
+
+        PasswordResetToken::invalidate_unused_for_user(&self.state.pool, user.id).await?;
+        let raw_token = self.state.token_service.generate_one_time_token();
+        let token_hash = self.state.token_service.hash_token(&raw_token);
+        PasswordResetToken::create(
             &self.state.pool,
-            user_id,
+            user.id,
             &token_hash,
-            self.state.token_service.refresh_expires_at(),
+            self.state.token_service.password_reset_token_expires_at(),
         )
         .await?;
 
-        Ok(tokens)
+        self.state
+            .mailer
+            .send_email(
+                &user.email,
+                "Password reset",
+                &format!("Hi {}, use this reset token: {}", user.first_name, raw_token),
+            )
+            .await?;
+
+        Ok(())
     }
 
-    fn hash_password(&self, password: &str) -> Result<String, AppError> {
+    pub async fn reset_password(&self, token: &str, new_password: &str) -> Result<(), AppError> {
+        let token_hash = self.state.token_service.hash_token(token);
+        let stored = PasswordResetToken::find_active_by_hash(&self.state.pool, &token_hash)
+            .await?
+            .ok_or_else(|| AppError::Unauthorized("Password reset token is invalid or expired.".to_string()))?;
+        let user = User::find_by_id(&self.state.pool, stored.user_id)
+            .await?
+            .ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
+        let password_hash = self.hash_password(new_password)?;
+
+        sqlx::query("UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2")
+            .bind(&password_hash)
+            .bind(user.id)
+            .execute(&self.state.pool)
+            .await?;
+        PasswordResetToken::mark_used(&self.state.pool, stored.id).await?;
+        RefreshToken::revoke_all_for_user(&self.state.pool, user.id).await?;
+
+        Ok(())
+    }
+
+    pub async fn build_user_response(&self, user_id: Uuid) -> Result<UserResponseData, AppError> {
+        let user = User::find_by_id(&self.state.pool, user_id)
+            .await?
+            .ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
+        let roles = Role::find_by_user_id(&self.state.pool, user_id).await?;
+        let permissions = Permission::find_by_user_id(&self.state.pool, user_id).await?;
+
+        Ok(UserResponseData::from_parts(user, roles, permissions))
+    }
+
+    pub fn hash_password(&self, password: &str) -> Result<String, AppError> {
         let salt = SaltString::generate(&mut OsRng);
         Argon2::default()
             .hash_password(password.as_bytes(), &salt)
@@ -144,76 +252,55 @@ impl AuthService {
             .verify_password(password.as_bytes(), &parsed_hash)
             .map_err(|_| AppError::Unauthorized("Invalid email or password.".to_string()))
     }
-}
 
-fn parse_uuid(value: &str) -> Result<Uuid, AppError> {
-    Uuid::parse_str(value).map_err(|_| AppError::Unauthorized("Invalid token subject.".to_string()))
-}
+    async fn issue_and_store_tokens(&self, user_id: Uuid) -> Result<TokenData, AppError> {
+        let tokens = self.state.token_service.issue_token_pair(user_id)?;
+        let token_hash = self.state.token_service.hash_token(&tokens.refresh_token);
+        RefreshToken::create(
+            &self.state.pool,
+            user_id,
+            &token_hash,
+            self.state.token_service.refresh_expires_at(),
+        )
+        .await?;
 
-impl AuthService {
-    pub async fn verify_email(&self, token: &str) -> Result<(), AppError> {
-        let claims = self
-            .state
-            .token_service
-            .decode_token(token, "verification")?;
-        let user_id = parse_uuid(&claims.sub)?;
-        let user = User::find_active_by_id(&self.state.pool, user_id)
-            .await?
-            .ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
-
-        if user.is_verified {
-            return Err(AppError::BadRequest("Email is already verified.".to_string()));
-        }
-
-        sqlx::query("UPDATE users SET is_verified = true, updated_at = NOW() WHERE id = $1")
-            .bind(user_id)
-            .execute(&self.state.pool)
-            .await?;
-
-        Ok(())
+        Ok(tokens)
     }
 
-    pub async fn forgot_password(&self, email: &str) -> Result<(), AppError> {
-        let email = email.trim().to_lowercase();
-        let user = match User::find_by_email(&self.state.pool, &email).await? {
-            Some(u) => u,
-            None => return Ok(()),
-        };
-
-        let reset_token = self
-            .state
-            .token_service
-            .create_verification_token(user.id, &user.email)?;
+    async fn issue_email_verification(&self, user: &User) -> Result<(), AppError> {
+        EmailVerificationToken::invalidate_unused_for_user(&self.state.pool, user.id).await?;
+        let raw_token = self.state.token_service.generate_one_time_token();
+        let token_hash = self.state.token_service.hash_token(&raw_token);
+        EmailVerificationToken::create(
+            &self.state.pool,
+            user.id,
+            &token_hash,
+            self.state.token_service.verification_token_expires_at(),
+        )
+        .await?;
 
         self.state
             .mailer
             .send_email(
                 &user.email,
-                "Password Reset",
-                &format!("Your password reset token is: {}", reset_token),
+                "Verify your account",
+                &format!("Welcome {}, use this verification token: {}", user.first_name, raw_token),
             )
             .await?;
 
         Ok(())
     }
 
-    pub async fn reset_password(&self, token: &str, new_password: &str) -> Result<(), AppError> {
-        let claims = self
-            .state
-            .token_service
-            .decode_token(token, "verification")?;
-        let user_id = parse_uuid(&claims.sub)?;
-        let user = User::find_active_by_id(&self.state.pool, user_id)
+    async fn assign_role_by_name(&self, user_id: Uuid, role_name: &str) -> Result<(), AppError> {
+        let role = Role::find_by_name(&self.state.pool, role_name)
             .await?
-            .ok_or_else(|| AppError::NotFound("User not found.".to_string()))?;
-
-        let password_hash = self.hash_password(new_password)?;
-        sqlx::query("UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2")
-            .bind(&password_hash)
-            .bind(user.id)
-            .execute(&self.state.pool)
-            .await?;
+            .ok_or_else(|| AppError::Internal(format!("Default role '{}' was not found.", role_name)))?;
+        UserRole::assign(&self.state.pool, user_id, role.id).await?;
 
         Ok(())
     }
+}
+
+fn parse_uuid(value: &str) -> Result<Uuid, AppError> {
+    Uuid::parse_str(value).map_err(|_| AppError::Unauthorized("Invalid token subject.".to_string()))
 }

--- a/src/services/token.rs
+++ b/src/services/token.rs
@@ -69,6 +69,18 @@ impl TokenService {
         })
     }
 
+    pub fn generate_one_time_token(&self) -> String {
+        format!("{}.{}", Uuid::new_v4(), Uuid::new_v4())
+    }
+
+    pub fn verification_token_expires_at(&self) -> chrono::DateTime<Utc> {
+        Utc::now() + Duration::days(1)
+    }
+
+    pub fn password_reset_token_expires_at(&self) -> chrono::DateTime<Utc> {
+        Utc::now() + Duration::hours(1)
+    }
+
     pub fn decode_token(&self, token: &str, expected_type: &str) -> Result<TokenClaims, AppError> {
         let mut validation = Validation::new(Algorithm::HS256);
         validation.validate_exp = true;


### PR DESCRIPTION
## Summary
- add database-backed email verification and password reset flows with hashed one-time tokens, MailHog delivery, and richer authenticated user responses
- expand RBAC persistence and expose role, permission, and user-management CRUD endpoints with effective role/permission lookups
- seed resource:action permissions and verify the stack with cargo build, docker-compose, and curl-based endpoint checks