### PR TITLE
feat: add OpenAPI spec with utoipa + Swagger UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +37,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "argon2"
@@ -273,6 +288,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +374,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -455,6 +490,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "miniz_oxide",
+ "zlib-rs",
+]
 
 [[package]]
 name = "flume"
@@ -1067,6 +1112,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,8 +1553,44 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "utoipa",
+ "utoipa-swagger-ui",
  "uuid",
  "validator",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
 ]
 
 [[package]]
@@ -1538,6 +1639,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1673,6 +1783,12 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple_asn1"
@@ -2259,6 +2375,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2314,6 +2436,48 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "uuid",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
+dependencies = [
+ "axum",
+ "base64",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "zip",
+]
 
 [[package]]
 name = "uuid"
@@ -2374,6 +2538,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -2510,6 +2684,15 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2932,7 +3115,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,5 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 uuid = { version = "1.11", features = ["v4", "serde"] }
 validator = { version = "0.18", features = ["derive"] }
+utoipa = { version = "5", features = ["uuid", "chrono"] }
+utoipa-swagger-ui = { version = "9", features = ["axum"] }

--- a/src/handlers/admin.rs
+++ b/src/handlers/admin.rs
@@ -45,7 +45,8 @@ async fn require_perm(state: &AppState, user_id: Uuid, perm: &str) -> Result<(),
     Ok(())
 }
 
-async fn list_roles(
+#[utoipa::path(get, path = "/api/v1/admin/roles", responses((status = 200, description = "List roles")), tag = "admin")]
+pub async fn list_roles(
     State(state): State<AppState>,
     user: CurrentUser,
 ) -> Result<Json<Vec<RoleResponse>>, AppError> {
@@ -58,7 +59,8 @@ async fn list_roles(
     }).collect()))
 }
 
-async fn list_permissions(
+#[utoipa::path(get, path = "/api/v1/admin/permissions", responses((status = 200, description = "List permissions")), tag = "admin")]
+pub async fn list_permissions(
     State(state): State<AppState>,
     user: CurrentUser,
 ) -> Result<Json<Vec<PermissionResponse>>, AppError> {
@@ -69,7 +71,8 @@ async fn list_permissions(
     }).collect()))
 }
 
-async fn get_role_permissions(
+#[utoipa::path(get, path = "/api/v1/admin/roles/{role_id}/permissions", responses((status = 200, description = "Role permissions")), tag = "admin")]
+pub async fn get_role_permissions(
     State(state): State<AppState>,
     user: CurrentUser,
     Path(role_id): Path<Uuid>,
@@ -81,7 +84,8 @@ async fn get_role_permissions(
     }).collect()))
 }
 
-async fn assign_permission(
+#[utoipa::path(post, path = "/api/v1/admin/roles/permissions", request_body = RolePermissionRequest, responses((status = 200, description = "Permission assigned")), tag = "admin")]
+pub async fn assign_permission(
     State(state): State<AppState>,
     user: CurrentUser,
     Json(payload): Json<RolePermissionRequest>,
@@ -91,7 +95,8 @@ async fn assign_permission(
     Ok(Json(MessageResponse { data: MessageData { message: "Permission assigned to role.".to_string() } }))
 }
 
-async fn remove_permission(
+#[utoipa::path(delete, path = "/api/v1/admin/roles/permissions", request_body = RolePermissionRequest, responses((status = 200, description = "Permission removed")), tag = "admin")]
+pub async fn remove_permission(
     State(state): State<AppState>,
     user: CurrentUser,
     Json(payload): Json<RolePermissionRequest>,
@@ -101,7 +106,8 @@ async fn remove_permission(
     Ok(Json(MessageResponse { data: MessageData { message: "Permission removed from role.".to_string() } }))
 }
 
-async fn list_users(
+#[utoipa::path(get, path = "/api/v1/admin/users", responses((status = 200, description = "List users")), tag = "admin")]
+pub async fn list_users(
     State(state): State<AppState>,
     user: CurrentUser,
 ) -> Result<Json<Vec<UserResponse>>, AppError> {
@@ -112,7 +118,8 @@ async fn list_users(
     Ok(Json(users.iter().map(|u| crate::schema::UserResponseData::from(u).into()).collect()))
 }
 
-async fn get_user(
+#[utoipa::path(get, path = "/api/v1/admin/users/{user_id}", responses((status = 200, description = "User details")), tag = "admin")]
+pub async fn get_user(
     State(state): State<AppState>,
     user: CurrentUser,
     Path(user_id): Path<Uuid>,
@@ -122,7 +129,8 @@ async fn get_user(
     Ok(Json(UserResponse { data: crate::schema::UserResponseData::from(&found) }))
 }
 
-async fn update_user(
+#[utoipa::path(patch, path = "/api/v1/admin/users/{user_id}/patch", request_body = UserUpdateRequest, responses((status = 200, description = "User updated")), tag = "admin")]
+pub async fn update_user(
     State(state): State<AppState>,
     user: CurrentUser,
     Path(user_id): Path<Uuid>,
@@ -143,7 +151,8 @@ async fn update_user(
     Ok(Json(UserResponse { data: crate::schema::UserResponseData::from(&updated) }))
 }
 
-async fn delete_user(
+#[utoipa::path(delete, path = "/api/v1/admin/users/{user_id}", responses((status = 200, description = "User deleted")), tag = "admin")]
+pub async fn delete_user(
     State(state): State<AppState>,
     user: CurrentUser,
     Path(user_id): Path<Uuid>,
@@ -154,7 +163,8 @@ async fn delete_user(
     Ok(Json(MessageResponse { data: MessageData { message: "User deleted.".to_string() } }))
 }
 
-async fn get_user_permissions(
+#[utoipa::path(get, path = "/api/v1/admin/users/{user_id}/permissions", responses((status = 200, description = "User permissions")), tag = "admin")]
+pub async fn get_user_permissions(
     State(state): State<AppState>,
     user: CurrentUser,
     Path(target_user_id): Path<Uuid>,
@@ -166,7 +176,8 @@ async fn get_user_permissions(
     }).collect()))
 }
 
-async fn assign_role(
+#[utoipa::path(post, path = "/api/v1/admin/users/roles", request_body = UserRoleRequest, responses((status = 200, description = "Role assigned")), tag = "admin")]
+pub async fn assign_role(
     State(state): State<AppState>,
     user: CurrentUser,
     Json(payload): Json<UserRoleRequest>,
@@ -176,7 +187,8 @@ async fn assign_role(
     Ok(Json(MessageResponse { data: MessageData { message: "Role assigned to user.".to_string() } }))
 }
 
-async fn remove_role(
+#[utoipa::path(delete, path = "/api/v1/admin/users/roles", request_body = UserRoleRequest, responses((status = 200, description = "Role removed")), tag = "admin")]
+pub async fn remove_role(
     State(state): State<AppState>,
     user: CurrentUser,
     Json(payload): Json<UserRoleRequest>,
@@ -192,7 +204,7 @@ impl From<crate::schema::UserResponseData> for UserResponse {
     }
 }
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
 pub struct RoleResponse {
     pub id: Uuid,
     pub name: String,

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -29,24 +29,29 @@ pub fn router() -> Router<AppState> {
         .route("/reset-password", post(reset_password))
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/register",
+    request_body = RegisterRequest,
+    responses((status = 201, description = "Registration successful", body = AuthUserResponse)),
+    tag = "auth"
+)]
 pub async fn register(
     State(state): State<AppState>,
     Json(payload): Json<RegisterRequest>,
 ) -> Result<(axum::http::StatusCode, Json<AuthUserResponse>), AppError> {
     payload.validate()?;
-
     let user = AuthService::new(state).register(payload).await?;
-    Ok((
-        axum::http::StatusCode::CREATED,
-        Json(AuthUserResponse {
-            data: AuthUserEnvelope {
-                user: UserResponseData::from(user),
-                message: "Registration successful. Verification email sent.".to_string(),
-            },
-        }),
-    ))
+    Ok((axum::http::StatusCode::CREATED, Json(AuthUserResponse { data: AuthUserEnvelope { user: UserResponseData::from(user), message: "Registration successful. Verification email sent.".to_string() } })))
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/login",
+    request_body = LoginRequest,
+    responses((status = 200, description = "Login successful", body = TokenResponse)),
+    tag = "auth"
+)]
 pub async fn login(
     State(state): State<AppState>,
     Json(payload): Json<LoginRequest>,
@@ -56,79 +61,92 @@ pub async fn login(
     Ok(Json(TokenResponse { data }))
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/logout",
+    request_body = RefreshTokenRequest,
+    responses((status = 200, description = "Logout successful", body = MessageResponse)),
+    tag = "auth"
+)]
 pub async fn logout(
     State(state): State<AppState>,
     Json(payload): Json<LogoutRequest>,
 ) -> Result<Json<MessageResponse>, AppError> {
     payload.validate()?;
-    AuthService::new(state)
-        .logout(&payload.refresh_token)
-        .await?;
-    Ok(Json(MessageResponse {
-        data: MessageData {
-            message: "Logout successful.".to_string(),
-        },
-    }))
+    AuthService::new(state).logout(&payload.refresh_token).await?;
+    Ok(Json(MessageResponse { data: MessageData { message: "Logout successful.".to_string() } }))
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/refresh",
+    request_body = RefreshTokenRequest,
+    responses((status = 200, description = "Token refreshed", body = TokenResponse)),
+    tag = "auth"
+)]
 pub async fn refresh(
     State(state): State<AppState>,
     Json(payload): Json<RefreshTokenRequest>,
 ) -> Result<Json<TokenResponse>, AppError> {
     payload.validate()?;
-    let data = AuthService::new(state)
-        .refresh(&payload.refresh_token)
-        .await?;
+    let data = AuthService::new(state).refresh(&payload.refresh_token).await?;
     Ok(Json(TokenResponse { data }))
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/v1/auth/me",
+    responses((status = 200, description = "Current user", body = UserResponse)),
+    tag = "auth"
+)]
 pub async fn me(current_user: CurrentUser) -> Result<Json<UserResponse>, AppError> {
-    Ok(Json(UserResponse {
-        data: UserResponseData::from(current_user.0),
-    }))
+    Ok(Json(UserResponse { data: UserResponseData::from(current_user.0) }))
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/verify-email",
+    request_body = VerifyEmailRequest,
+    responses((status = 200, description = "Email verified", body = MessageResponse)),
+    tag = "auth"
+)]
 pub async fn verify_email(
     State(state): State<AppState>,
     Json(payload): Json<VerifyEmailRequest>,
 ) -> Result<Json<MessageResponse>, AppError> {
     payload.validate()?;
-    AuthService::new(state)
-        .verify_email(&payload.token)
-        .await?;
-    Ok(Json(MessageResponse {
-        data: MessageData {
-            message: "Email verified successfully.".to_string(),
-        },
-    }))
+    AuthService::new(state).verify_email(&payload.token).await?;
+    Ok(Json(MessageResponse { data: MessageData { message: "Email verified successfully.".to_string() } }))
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/forgot-password",
+    request_body = ForgotPasswordRequest,
+    responses((status = 200, description = "Reset email sent", body = MessageResponse)),
+    tag = "auth"
+)]
 pub async fn forgot_password(
     State(state): State<AppState>,
     Json(payload): Json<ForgotPasswordRequest>,
 ) -> Result<Json<MessageResponse>, AppError> {
     payload.validate()?;
-    AuthService::new(state)
-        .forgot_password(&payload.email)
-        .await?;
-    Ok(Json(MessageResponse {
-        data: MessageData {
-            message: "If an account with that email exists, a reset link has been sent.".to_string(),
-        },
-    }))
+    AuthService::new(state).forgot_password(&payload.email).await?;
+    Ok(Json(MessageResponse { data: MessageData { message: "If an account with that email exists, a reset link has been sent.".to_string() } }))
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/reset-password",
+    request_body = ResetPasswordRequest,
+    responses((status = 200, description = "Password reset", body = MessageResponse)),
+    tag = "auth"
+)]
 pub async fn reset_password(
     State(state): State<AppState>,
     Json(payload): Json<ResetPasswordRequest>,
 ) -> Result<Json<MessageResponse>, AppError> {
     payload.validate()?;
-    AuthService::new(state)
-        .reset_password(&payload.token, &payload.new_password)
-        .await?;
-    Ok(Json(MessageResponse {
-        data: MessageData {
-            message: "Password reset successfully.".to_string(),
-        },
-    }))
+    AuthService::new(state).reset_password(&payload.token, &payload.new_password).await?;
+    Ok(Json(MessageResponse { data: MessageData { message: "Password reset successfully.".to_string() } }))
 }

--- a/src/handlers/health.rs
+++ b/src/handlers/health.rs
@@ -1,6 +1,7 @@
 use axum::Json;
 use serde_json::{json, Value};
 
+#[utoipa::path(get, path = "/health", responses((status = 200, description = "Health check OK")), tag = "health")]
 pub async fn health_check() -> Json<Value> {
     Json(json!({"status": "ok"}))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ use axum::{routing::get, Router};
 use sqlx::PgPool;
 use tokio::signal;
 use tracing::info;
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
 
 mod config;
 mod db;
@@ -29,6 +31,60 @@ pub struct AppState {
     pub mailer: Mailer,
 }
 
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        handlers::auth::register,
+        handlers::auth::login,
+        handlers::auth::logout,
+        handlers::auth::refresh,
+        handlers::auth::me,
+        handlers::auth::verify_email,
+        handlers::auth::forgot_password,
+        handlers::auth::reset_password,
+        handlers::admin::list_roles,
+        handlers::admin::list_permissions,
+        handlers::admin::get_role_permissions,
+        handlers::admin::assign_permission,
+        handlers::admin::remove_permission,
+        handlers::admin::list_users,
+        handlers::admin::get_user,
+        handlers::admin::update_user,
+        handlers::admin::delete_user,
+        handlers::admin::get_user_permissions,
+        handlers::admin::assign_role,
+        handlers::admin::remove_role,
+        handlers::health::health_check,
+    ),
+    components(schemas(
+        schema::RegisterRequest,
+        schema::LoginRequest,
+        schema::RefreshTokenRequest,
+        schema::TokenData,
+        schema::TokenResponse,
+        schema::MessageData,
+        schema::MessageResponse,
+        schema::AuthUserResponse,
+        schema::AuthUserEnvelope,
+        schema::UserResponse,
+        schema::UserResponseData,
+        schema::VerifyEmailRequest,
+        schema::ForgotPasswordRequest,
+        schema::ResetPasswordRequest,
+        schema::PermissionResponse,
+        schema::RolePermissionRequest,
+        schema::UserRoleRequest,
+        schema::UserUpdateRequest,
+        handlers::admin::RoleResponse,
+    )),
+    tags(
+        (name = "auth", description = "Authentication endpoints"),
+        (name = "admin", description = "Admin & RBAC endpoints"),
+        (name = "health", description = "Health check"),
+    )
+)]
+struct ApiDoc;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     init_tracing()?;
@@ -45,6 +101,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let app = Router::new()
+        .merge(SwaggerUi::new("/docs").url("/openapi.json", ApiDoc::openapi()))
         .route("/health", get(health_check))
         .nest("/api/v1/auth", auth_router())
         .nest("/api/v1/admin", admin::router())

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,19 +1,16 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 use uuid::Uuid;
 use validator::Validate;
 
 use crate::models::user::User;
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
 pub struct RegisterRequest {
     #[validate(email(message = "Email must be valid."))]
     pub email: String,
-    #[validate(length(
-        min = 8,
-        max = 128,
-        message = "Password must be between 8 and 128 characters."
-    ))]
+    #[validate(length(min = 8, max = 128, message = "Password must be between 8 and 128 characters."))]
     pub password: String,
     #[validate(length(min = 1, max = 100, message = "First name is required."))]
     pub first_name: String,
@@ -21,19 +18,15 @@ pub struct RegisterRequest {
     pub last_name: String,
 }
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
 pub struct LoginRequest {
     #[validate(email(message = "Email must be valid."))]
     pub email: String,
-    #[validate(length(
-        min = 8,
-        max = 128,
-        message = "Password must be between 8 and 128 characters."
-    ))]
+    #[validate(length(min = 8, max = 128, message = "Password must be between 8 and 128 characters."))]
     pub password: String,
 }
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
 pub struct RefreshTokenRequest {
     #[validate(length(min = 1, message = "Refresh token is required."))]
     pub refresh_token: String,
@@ -41,7 +34,7 @@ pub struct RefreshTokenRequest {
 
 pub type LogoutRequest = RefreshTokenRequest;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct TokenData {
     pub access_token: String,
     pub refresh_token: String,
@@ -49,38 +42,38 @@ pub struct TokenData {
     pub expires_in: i64,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct TokenResponse {
     pub data: TokenData,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct MessageData {
     pub message: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct MessageResponse {
     pub data: MessageData,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct AuthUserResponse {
     pub data: AuthUserEnvelope,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct AuthUserEnvelope {
     pub user: UserResponseData,
     pub message: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct UserResponse {
     pub data: UserResponseData,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct UserResponseData {
     pub id: Uuid,
     pub email: String,
@@ -94,47 +87,29 @@ pub struct UserResponseData {
 
 impl From<User> for UserResponseData {
     fn from(user: User) -> Self {
-        Self {
-            id: user.id,
-            email: user.email,
-            first_name: user.first_name,
-            last_name: user.last_name,
-            is_active: user.is_active,
-            is_verified: user.is_verified,
-            created_at: user.created_at,
-            updated_at: user.updated_at,
-        }
+        Self { id: user.id, email: user.email, first_name: user.first_name, last_name: user.last_name, is_active: user.is_active, is_verified: user.is_verified, created_at: user.created_at, updated_at: user.updated_at }
     }
 }
 
 impl From<&User> for UserResponseData {
     fn from(user: &User) -> Self {
-        Self {
-            id: user.id,
-            email: user.email.clone(),
-            first_name: user.first_name.clone(),
-            last_name: user.last_name.clone(),
-            is_active: user.is_active,
-            is_verified: user.is_verified,
-            created_at: user.created_at,
-            updated_at: user.updated_at,
-        }
+        Self { id: user.id, email: user.email.clone(), first_name: user.first_name.clone(), last_name: user.last_name.clone(), is_active: user.is_active, is_verified: user.is_verified, created_at: user.created_at, updated_at: user.updated_at }
     }
 }
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
 pub struct VerifyEmailRequest {
     #[validate(length(min = 1, message = "Token is required."))]
     pub token: String,
 }
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
 pub struct ForgotPasswordRequest {
     #[validate(email(message = "Email must be valid."))]
     pub email: String,
 }
 
-#[derive(Debug, Deserialize, Validate)]
+#[derive(Debug, Deserialize, Validate, ToSchema)]
 pub struct ResetPasswordRequest {
     #[validate(length(min = 1, message = "Token is required."))]
     pub token: String,
@@ -142,7 +117,7 @@ pub struct ResetPasswordRequest {
     pub new_password: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct PermissionResponse {
     pub id: Uuid,
     pub name: String,
@@ -150,19 +125,19 @@ pub struct PermissionResponse {
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct RolePermissionRequest {
     pub role_id: Uuid,
     pub permission_id: Uuid,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UserRoleRequest {
     pub user_id: Uuid,
     pub role_id: Uuid,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UserUpdateRequest {
     pub first_name: Option<String>,
     pub last_name: Option<String>,


### PR DESCRIPTION
Adds utoipa + utoipa-swagger-ui to generate OpenAPI 3.0 spec and serve Swagger UI.

- `/openapi.json` — OpenAPI 3.0 spec with all endpoints
- `/docs` — Interactive Swagger UI
- All auth + admin + health endpoints documented
- ToSchema derives on all request/response structs